### PR TITLE
ci: cancel concurrent jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,8 +8,12 @@ on:
          - "v*.*.*"
 
 jobs:
-   build-and-deploy:
+   deploy-dev:
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
       runs-on: ubuntu-latest
+      concurrency:
+         group: deploy-dev
+         cancel-in-progress: true
       steps:
          - uses: actions/checkout@v4
 
@@ -47,20 +51,59 @@ jobs:
               SHINYAPPS_TOKEN: ${{ secrets.SHINYAPPS_TOKEN }}
               SHINYAPPS_SECRET: ${{ secrets.SHINYAPPS_SECRET }}
 
-         - name: Deploy to Development or Production
+         - name: Deploy to Development
            run: |
-              if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == "v*" ]]; then
-                echo "Deploying to production app $PROD_APP_ID"
-                rsconnect deploy shiny . \
-                  --name "$SHINYAPPS_NAME" \
-                  --app-id "$PROD_APP_ID"
-              else
-                echo "Deploying to development app $DEV_APP_ID"
-                rsconnect deploy shiny . \
-                  --name  "$SHINYAPPS_NAME" \
-                  --app-id "$DEV_APP_ID"
-              fi
+              rsconnect deploy shiny . \
+                --name  "$SHINYAPPS_NAME" \
+                --app-id "$DEV_APP_ID"
+           env:
+              SHINYAPPS_NAME: ${{ secrets.SHINYAPPS_NAME }}
+              DEV_APP_ID: ${{ secrets.DEV_APP_ID }}
+
+   deploy-prod:
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      runs-on: ubuntu-latest
+      concurrency:
+         group: deploy-prod
+         cancel-in-progress: true
+      steps:
+         - uses: actions/checkout@v4
+
+         - name: Set up Python 3.9
+           uses: actions/setup-python@v5
+           with:
+              python-version: "3.9.13" # Specific version required by shinyapps.io
+
+         - name: Install dependencies
+           run: |
+              python -m pip install -r requirements.txt
+
+         - name: Install Quarto
+           run: |
+              wget https://quarto.org/download/latest/quarto-linux-amd64.deb
+              sudo dpkg -i quarto-linux-amd64.deb
+
+         - name: Build the app
+           run: |
+              quarto render index.qmd
+
+         - name: Configure deployment tool
+           run: |
+              rsconnect add \
+                --account $SHINYAPPS_NAME \
+                --name $SHINYAPPS_NAME \
+                --token $SHINYAPPS_TOKEN \
+                --secret $SHINYAPPS_SECRET
+           env:
+              SHINYAPPS_NAME: ${{ secrets.SHINYAPPS_NAME }}
+              SHINYAPPS_TOKEN: ${{ secrets.SHINYAPPS_TOKEN }}
+              SHINYAPPS_SECRET: ${{ secrets.SHINYAPPS_SECRET }}
+
+         - name: Deploy to Production
+           run: |
+              rsconnect deploy shiny . \
+                --name "$SHINYAPPS_NAME" \
+                --app-id "$PROD_APP_ID"
            env:
               SHINYAPPS_NAME: ${{ secrets.SHINYAPPS_NAME }}
               PROD_APP_ID: ${{ secrets.PROD_APP_ID }}
-              DEV_APP_ID: ${{ secrets.DEV_APP_ID }}


### PR DESCRIPTION
Cancel a previous job if a new one appears for the same environment. This will hopefully avoid deployment conflicts. Had to split the dev and prod deployments which has results in some duplicate code. Could look to reduce the duplication later if needed.