### PR TITLE
ci: ensure prod deploy includes pendo keys

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,6 +91,14 @@ jobs:
               wget https://quarto.org/download/latest/quarto-linux-amd64.deb
               sudo dpkg -i quarto-linux-amd64.deb
 
+         - name: Replace secrets placeholders
+           run: |
+              sed -i "s|__PENDO_API_KEY__|${PENDO_API_KEY}|g" www/pendo-analytics.html
+              sed -i "s|__GOOGLE_API_KEY__|${GOOGLE_API_KEY}|g" www/google-analytics.html
+           env:
+              PENDO_API_KEY: ${{ secrets.PENDO_API_KEY }}
+              GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+
          - name: Build the app
            run: |
               quarto render index.qmd

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,11 @@ At the time of writing, [shinyapps.io only supports python 3.7.13, 3.8.13, 3.9.1
 -  **Create** a Python 3.9.x Anaconda environment `conda create -n eeud python=3.9` and **activate** it `conda activate eeud`.
 -  **Navigate** your terminal into the project directory if you have not already done so.
 -  **Install** required Python libraries `python -m pip install -r requirements.txt`.
+-  **Install** quarto
+```bash
+wget https://quarto.org/download/latest/quarto-linux-amd64.deb
+sudo dpkg -i quarto-linux-amd64.deb
+```
 -  **Render** the quarto document `quarto render index.qmd`. In this instance, `quarto` runs the CLI tool we installed earlier, and renders the dashboard, writing out a number of new files, including an html file and an app.py file.
 -  **Host** the shiny app `shiny run app.py`. In this instance, `shiny` executes a runtime package that is part of our Python environment, installed from our requirements.
 


### PR DESCRIPTION
Looks like pendo keys were not being deployed to prod, only dev.

Untested. Will need to run the prod deploy action to test this.