### PR TITLE
Grouped filter options

### DIFF
--- a/data/eeud-colour-palette-2026.csv
+++ b/data/eeud-colour-palette-2026.csv
@@ -1,6 +1,6 @@
 Dimension,Label,Colour
-EndUseGroup,Unknown,#808080
-EndUse,Unknown,#C0C0C0
+EndUseGroup,Unknown,#000000
+EndUse,Unknown,#000000
 EndUseGroup,Electronics and Lighting,#4977b5
 EndUseGroup,Heating/Cooling,#3a93ae
 EndUseGroup,Iron and Steel,#00a9ab
@@ -28,8 +28,8 @@ EndUse,"Low Temperature Heat (<100 C), Clothes Drying",#3a93ae
 EndUse,"Motive Power, Stationary",#36dfa8
 EndUse,Pumping,#12593c
 EndUse,Iron and Steel Manufacturing,#4ddec9
-FuelGroup,Unknown,#808080
-Fuel,Unknown,#C0C0C0
+FuelGroup,Unknown,#000000
+Fuel,Unknown,#000000
 FuelGroup,Electricity,#3a93ae
 FuelGroup,Fossil Fuels,#854c95
 FuelGroup,Renewables,#2fbb8b
@@ -45,7 +45,7 @@ Fuel,Wood,#36dfa8
 Fuel,Geothermal,#12593c
 Fuel,Solar,#2cb081
 Fuel,Biogas,#20835d
-SectorGroup,Unknown,#808080
+SectorGroup,Unknown,#000000
 Sector,Unknown,#45d5c4
 SectorGroup,"Agriculture, Forestry and Fishing",#2fbb8b
 SectorGroup,Commercial,#00a9ab
@@ -92,8 +92,8 @@ Sector,Road Transport,#6c2872
 Sector,Air Transport,#d2b6ff
 Sector,Sea Transport,#8d57a0
 Sector,Rail Transport,#af86cf
-TechnologyGroup,Unknown,#808080
-Technology,Unknown,#C0C0C0
+TechnologyGroup,Unknown,#000000
+Technology,Unknown,#000000
 TechnologyGroup,Bus,#854c95
 TechnologyGroup,Electronics and Lights,#3881b6
 TechnologyGroup,Freight Rail,#854c95

--- a/eeca.scss
+++ b/eeca.scss
@@ -41,12 +41,34 @@ $border-radius: 0 !default;
 /* Layout */
 
 :root {
-    --dashboard-height: 1000px;
+    --dashboard-embedded-min-height: 1000px;
+    --dashboard-header-height: 0px;
+    --dashboard-height: 100vh;
+    --dashboard-content-height: calc(var(--dashboard-height) - var(--dashboard-header-height));
+}
+
+@supports (height: 100dvh) {
+    :root {
+        --dashboard-height: 100dvh;
+    }
+}
+
+html.dashboard-embedded {
+    --dashboard-height: var(--dashboard-embedded-min-height);
 }
 
 html,
 body {
-    min-height: var(--dashboard-height) !important;
+    height: var(--dashboard-height) !important;
+    min-height: 0 !important;
+    overflow: hidden;
+}
+
+html.dashboard-embedded,
+body.dashboard-embedded {
+    height: var(--dashboard-height) !important;
+    min-height: var(--dashboard-embedded-min-height) !important;
+    max-height: var(--dashboard-height) !important;
 }
 
 body {
@@ -59,7 +81,8 @@ body {
     &.quarto-dashboard.dashboard-fill {
         display: flex;
         flex-direction: column;
-        min-height: var(--dashboard-height);
+        height: var(--dashboard-height);
+        min-height: 0;
         overflow: hidden;
     }
 }
@@ -91,11 +114,16 @@ label {
 
 .quarto-dashboard-content {
     flex: 1 1 auto;
+    height: var(--dashboard-content-height) !important;
+    max-height: var(--dashboard-content-height) !important;
     min-height: 0 !important;
+    overflow: hidden;
 
     > .tab-content {
         height: 100%;
+        max-height: 100%;
         min-height: 0 !important;
+        overflow: hidden;
     }
 }
 
@@ -105,21 +133,65 @@ label {
 .bslib-sidebar-layout > .sidebar,
 .bslib-sidebar-layout .sidebar-content {
     height: 100%;
+    max-height: 100%;
     min-height: 0 !important;
+    overflow: hidden;
+}
+
+.dashboard-sidebar-container {
+    grid-template-rows: minmax(0, 1fr) !important;
+    overflow: hidden;
+
+    .bslib-grid {
+        min-height: 0 !important;
+        overflow: hidden;
+    }
 }
 
 .bslib-sidebar-layout {
+    max-height: 100%;
+
     > .main,
     .sidebar-content {
+        max-height: 100%;
         overflow: hidden;
     }
 
     .sidebar {
         background-color: $silver !important;
         border: 0 !important;
-        overflow-y: auto !important;
-        padding-left: $def-padding !important;
-        padding-right: $def-padding !important;
+        height: 100% !important;
+        max-height: 100%;
+        overflow: hidden !important;
+        padding: 0 !important;
+
+        > .html-fill-container,
+        > .html-fill-item {
+            box-sizing: border-box;
+            display: block !important;
+            height: 100% !important;
+            max-height: 100% !important;
+            min-height: 0 !important;
+            overflow-x: hidden !important;
+            overflow-y: auto !important;
+            padding: calc($def-padding * 2) $def-padding calc($def-padding * 2) calc($def-padding * 2) !important;
+            scrollbar-color: rgba($black, 0.25) $white;
+        }
+
+        > .html-fill-container::-webkit-scrollbar,
+        > .html-fill-item::-webkit-scrollbar {
+            background: $white !important;
+        }
+
+        > .html-fill-container::-webkit-scrollbar-track,
+        > .html-fill-item::-webkit-scrollbar-track {
+            background: $white !important;
+        }
+
+        > .html-fill-container::-webkit-scrollbar-thumb,
+        > .html-fill-item::-webkit-scrollbar-thumb {
+            background-color: rgba($black, 0.25) !important;
+        }
     }
 }
 
@@ -692,7 +764,7 @@ $slider-selected-color: $sky-blue;
 }
 
 .chart-type-button-label {
-    align-items: flex-end !important;
+    align-items: center !important;
     display: inline-flex !important;
     gap: 0.35rem !important;
 }
@@ -705,17 +777,17 @@ $slider-selected-color: $sky-blue;
 }
 
 .chart-type-button-icon {
-    align-self: flex-end !important;
+    align-self: center !important;
     color: inherit !important;
     display: inline-flex !important;
     flex: 0 0 auto !important;
-    height: 1.3rem !important;
+    height: 1rem !important;
     justify-content: center !important;
     line-height: 1 !important;
-    margin-bottom: -0.02rem !important;
+    margin-bottom: 0 !important;
     text-align: center !important;
-    transform: translateY(calc(($def-padding / 2) + 2.5px)) !important;
-    width: 1.3rem !important;
+    transform: translateY(1px) !important;
+    width: 1rem !important;
 }
 
 .chart-type-button-icon svg {
@@ -732,7 +804,7 @@ $slider-selected-color: $sky-blue;
 #explore_sankey,
 #timeseries_area,
 #timeseries_line {
-    --chart-type-button-underline-left-inset: 4px;
+    --chart-type-button-underline-left-inset: 1px;
     --chart-type-button-underline-offset: 0.2rem;
     background-color: transparent !important;
     border: 0 !important;
@@ -914,7 +986,7 @@ $slider-selected-color: $sky-blue;
     background: $white !important;
     border: 0 !important;
     border-radius: 0 !important;
-    box-shadow: 0 2px 4px rgba($black, 0.15) !important;
+    box-shadow: 0 0px 0px rgba($black, 0.15) !important;
     margin-top: 0 !important;
     top: 100% !important;
 }
@@ -924,8 +996,64 @@ $slider-selected-color: $sky-blue;
     color: black !important;
 }
 
+.selectize-dropdown .optgroup:before {
+    border-top-color: $secondary !important;
+}
+
+.selectize-dropdown .optgroup-header {
+    //background: $silver !important;
+    color: black !important;
+    font-size: 16px !important;
+    font-weight: $medium !important;
+    //font-stretch: condensed !important;
+    //line-height: 1.2 !important;
+    //padding: 0.5rem 0.5rem 0.45rem 0.75rem !important;
+}
+
+.selectize-dropdown .optgroup .option {
+    padding-left: 1.5rem !important;
+}
+
+.selectize-dropdown.multi-selectize-group-actions .multi-selectize-group-header {
+    align-items: center;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: space-between;
+}
+
+.selectize-dropdown.multi-selectize-group-actions .multi-selectize-add-group {
+    align-items: center;
+    appearance: none;
+    background: $white;
+    border: 0;
+    border-radius: 0px;
+    color: black;
+    cursor: pointer;
+    display: inline-flex;
+    flex: 0 0 auto;
+    font-size: 18px;
+    font-weight: $bold;
+    height: 1.75rem;
+    justify-content: center;
+    line-height: 1;
+    margin-left: $def-padding;
+    margin-right: -$def-padding;
+    padding: 0;
+    width: 1.75rem;
+}
+
+.selectize-dropdown.multi-selectize-group-actions .multi-selectize-add-group:hover,
+.selectize-dropdown.multi-selectize-group-actions .multi-selectize-add-group:focus,
+.selectize-dropdown.multi-selectize-group-actions .multi-selectize-add-group:focus-visible {
+    background: $secondary;
+    outline: 0px solid $sky-blue;
+    outline-offset: 0px;
+}
+
 .selectize-dropdown-content {
     background: $white !important;
+    max-height: var(--selectize-dropdown-max-height, 420px) !important;
+    overflow-y: auto !important;
     scrollbar-color: rgba($black, 0.25) $white;
 }
 
@@ -939,8 +1067,7 @@ $slider-selected-color: $sky-blue;
 }
 
 .selectize-dropdown .option:hover,
-.selectize-dropdown .option.active,
-.selectize-dropdown .active {
+.selectize-dropdown.selectize-keyboard-active .option.active {
     background: $secondary !important;
     color: black !important;
 }

--- a/index.qmd
+++ b/index.qmd
@@ -15,11 +15,17 @@ format:
         - text: |
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css">
         - text: |
+            <script src="www/embedded-dashboard-behaviour.js"></script>
+        - text: |
             <script async src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child@latest" type="text/javascript"></script>
         - text: |
             <script src="www/slider-label-bounds.js"></script>
         - text: |
             <script src="www/single-selectize-behaviour.js"></script>
+        - text: |
+            <script src="www/multi-selectize-behaviour.js"></script>
+        - text: |
+            <script src="www/selectize-dropdown-sizing.js"></script>
 server: shiny
 ---
 
@@ -57,6 +63,21 @@ eeud_colours = pd.read_csv('./data/eeud-colour-palette-2026.csv', header=0, dtyp
 eeud_colours = eeud_colours[~eeud_colours.index.duplicated()]
 
 fill_unknown_columns = ['EndUse', 'Fuel', 'Sector', 'Technology', 'EndUseGroup', 'FuelGroup', 'SectorGroup', 'TechnologyGroup']
+TRANSPORT_TECHNOLOGY_GROUPS = [
+    'Bus',
+    'Freight Rail',
+    'Heavy Truck',
+    'Light Commercial Vehicle',
+    'Light Passenger Vehicle',
+    'Light Truck',
+    'Medium Truck',
+    'Mobile Motors',
+    'Motorcycle',
+    'Passenger Rail',
+    'Plane',
+    'Ship',
+    'Very Heavy Truck',
+]
 
 for column in fill_unknown_columns:
     if column in eeud.columns:
@@ -72,6 +93,65 @@ technologies_list = list(eeud['Technology'].dropna().sort_values().unique())
 years_list = list(eeud['Period'].dropna().sort_values(ascending=False).unique())
 end_uses_list = list(eeud['EndUse'].dropna().sort_values().unique())
 sector_groups = {group: set(sub_df['Sector'].dropna()) for group, sub_df in eeud.groupby('SectorGroup')}
+
+def grouped_selectize_choices(data, group_column, value_column):
+    values_by_group = (
+        data[[group_column, value_column]]
+        .dropna()
+        .drop_duplicates()
+        .sort_values([group_column, value_column])
+    )
+    values_by_group = values_by_group[
+        (values_by_group[group_column] != 'Unknown') &
+        (values_by_group[value_column] != 'Unknown')
+    ]
+
+    return {
+        str(group): {str(value): str(value) for value in group_data[value_column]}
+        for group, group_data in values_by_group.groupby(group_column, sort=False)
+    }
+
+def technology_selectize_choices(data):
+    technology_choices = data.copy()
+    technology_choices['TechnologyGroup'] = technology_choices['TechnologyGroup'].apply(
+        lambda group: 'Transport' if group in TRANSPORT_TECHNOLOGY_GROUPS else group
+    )
+    technology_choices = technology_choices[
+        (technology_choices['TechnologyGroup'] != 'Unknown') &
+        (technology_choices['Technology'] != 'Unknown')
+    ]
+
+    if 'TJ' in technology_choices.columns:
+        technology_group_weights = (
+            technology_choices
+            .groupby(['Technology', 'TechnologyGroup'], as_index=False)['TJ']
+            .sum()
+            .rename(columns={'TJ': 'GroupWeight'})
+        )
+    else:
+        technology_group_weights = (
+            technology_choices
+            .groupby(['Technology', 'TechnologyGroup'], as_index=False)
+            .size()
+            .rename(columns={'size': 'GroupWeight'})
+        )
+
+    majority_technology_groups = (
+        technology_group_weights
+        .sort_values(
+            ['Technology', 'GroupWeight', 'TechnologyGroup'],
+            ascending=[True, False, True]
+        )
+        .drop_duplicates('Technology', keep='first')
+        [['TechnologyGroup', 'Technology']]
+    )
+
+    return grouped_selectize_choices(majority_technology_groups, 'TechnologyGroup', 'Technology')
+
+end_uses_selectize_choices = grouped_selectize_choices(eeud, 'EndUseGroup', 'EndUse')
+fuels_selectize_choices = grouped_selectize_choices(eeud, 'FuelGroup', 'Fuel')
+sectors_selectize_choices = grouped_selectize_choices(eeud, 'SectorGroup', 'Sector')
+technologies_selectize_choices = technology_selectize_choices(eeud)
 
 ```
 
@@ -842,8 +922,7 @@ def display_trend():
     category = title_case(input.highlight_category())
     group = category + "Group"
     eeud_subset = eeud[~pd.isna(eeud[category])].copy()
-    to_replace = ['Bus', 'Freight Rail', 'Heavy Truck', 'Light Commercial Vehicle', 'Light Passenger Vehicle', 'Medium Truck', 'Motorcycle', 'Passenger Rail', 'Plane', 'Ship', 'Very Heavy Truck', 'Mobile Motors']
-    eeud_subset['TechnologyGroup'] = eeud_subset['TechnologyGroup'].apply(lambda g: 'Transport' if g in to_replace else g)
+    eeud_subset['TechnologyGroup'] = eeud_subset['TechnologyGroup'].apply(lambda g: 'Transport' if g in TRANSPORT_TECHNOLOGY_GROUPS else g)
 
     grouped = eeud_subset.groupby([group, 'Period']).sum(numeric_only=True).reset_index()
     total_tj_by_period = grouped.groupby('Period')['TJ'].sum().reset_index(name='TotalTJ')
@@ -891,8 +970,7 @@ def display_treemap():
     category = title_case(input.highlight_category())
     group = category + "Group"
     eeud_subset = eeud[(~pd.isna(eeud[category]))].copy()
-    to_replace = ['Bus', 'Freight Rail', 'Heavy Truck', 'Light Commercial Vehicle', 'Light Passenger Vehicle', 'Medium Truck', 'Motorcycle', 'Passenger Rail', 'Plane', 'Ship', 'Very Heavy Truck', 'Mobile Motors']
-    eeud_subset['TechnologyGroup'] = eeud_subset['TechnologyGroup'].apply(lambda g: 'Transport' if g in to_replace else g)
+    eeud_subset['TechnologyGroup'] = eeud_subset['TechnologyGroup'].apply(lambda g: 'Transport' if g in TRANSPORT_TECHNOLOGY_GROUPS else g)
     data_last_year = eeud_subset[eeud_subset['Period'].isin([eeud_subset['Period'].max()])]
     eeud_aggregated = data_last_year.groupby([group, category], as_index=False).agg({'TJ': 'sum'})
 
@@ -996,28 +1074,28 @@ ui.input_selectize(
 sectors_dict = {'Residential': ['All Residential', 'Residential', 'Residential Unallocated'],
     'Industrial': ['All Industrial', 'Construction', 'Dairy', 'Manufacturing']}
 
-ui.input_selectize('explore_end_use', "End Use", end_uses_list, multiple=True,
+ui.input_selectize('explore_end_use', "End Use", end_uses_selectize_choices, multiple=True,
     options={
         'placeholder': "All End Uses",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('explore_fuels', "Fuel Type", fuels_list, multiple=True, 
+ui.input_selectize('explore_fuels', "Fuel Type", fuels_selectize_choices, multiple=True,
     options={
         'placeholder': "All Fuel Types",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('explore_sectors', "Sector", sectors_list, multiple=True,
+ui.input_selectize('explore_sectors', "Sector", sectors_selectize_choices, multiple=True,
     options={
         'placeholder': "All Sectors",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('explore_technologies', "Technology", technologies_list, multiple=True,
+ui.input_selectize('explore_technologies', "Technology", technologies_selectize_choices, multiple=True,
     options={
         'placeholder': "All Technologies",
         'plugins': ['clear_button']
@@ -1209,28 +1287,28 @@ ui.input_selectize(
 
 ```{python}
 
-ui.input_selectize('timeseries_end_use', "End Use", end_uses_list, multiple=True,
+ui.input_selectize('timeseries_end_use', "End Use", end_uses_selectize_choices, multiple=True,
     options={
         'placeholder': "All End Uses",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('timeseries_fuels', "Fuel Type", fuels_list, multiple=True, 
+ui.input_selectize('timeseries_fuels', "Fuel Type", fuels_selectize_choices, multiple=True,
     options={
         'placeholder': "All Fuel Types",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('timeseries_sectors', "Sector", sectors_list, multiple=True,
+ui.input_selectize('timeseries_sectors', "Sector", sectors_selectize_choices, multiple=True,
     options={
         'placeholder': "All Sectors",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('timeseries_technologies', "Technology", technologies_list, multiple=True,
+ui.input_selectize('timeseries_technologies', "Technology", technologies_selectize_choices, multiple=True,
     options={
         'placeholder': "All Technologies",
         'plugins': ['clear_button']
@@ -1425,28 +1503,28 @@ def display_timeseries_chart():
 <h5>Filter</h5>
 
 ```{python}
-ui.input_selectize('data_end_use', "End Use", end_uses_list, multiple=True,
+ui.input_selectize('data_end_use', "End Use", end_uses_selectize_choices, multiple=True,
     options={
         'placeholder': "All End Uses",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('data_fuels', "Fuel Type", fuels_list, multiple=True, 
+ui.input_selectize('data_fuels', "Fuel Type", fuels_selectize_choices, multiple=True,
     options={
         'placeholder': "All Fuel Types",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('data_sectors', "Sector", sectors_list, multiple=True,
+ui.input_selectize('data_sectors', "Sector", sectors_selectize_choices, multiple=True,
     options={
         'placeholder': "All Sectors",
         'plugins': ['clear_button']
     }
 )
 
-ui.input_selectize('data_technologies', "Technology", technologies_list, multiple=True,
+ui.input_selectize('data_technologies', "Technology", technologies_selectize_choices, multiple=True,
     options={
         'placeholder': "All Technologies",
         'plugins': ['clear_button']

--- a/www/embedded-dashboard-behaviour.js
+++ b/www/embedded-dashboard-behaviour.js
@@ -1,0 +1,216 @@
+(() => {
+  const EMBEDDED_CLASS = "dashboard-embedded";
+  const SIZING_ELEMENT_ID = "dashboard-iframe-size";
+  const SIZING_ATTRIBUTE = "data-iframe-size";
+  const EMBEDDED_MIN_HEIGHT = 1000;
+  const RESIZE_DEBOUNCE_MS = 60;
+
+  let resizeTimer = null;
+
+  const isEmbedded = () => {
+    try {
+      return window.self !== window.top;
+    } catch (error) {
+      return true;
+    }
+  };
+
+  const isDashboardEmbedded = () => (
+    document.documentElement.classList.contains(EMBEDDED_CLASS)
+  );
+
+  const embeddedMinHeight = () => {
+    const value = window.getComputedStyle(document.documentElement)
+      .getPropertyValue("--dashboard-embedded-min-height");
+    const minHeight = Number.parseFloat(value);
+
+    return Number.isFinite(minHeight) ? minHeight : EMBEDDED_MIN_HEIGHT;
+  };
+
+  const embeddedDashboardHeight = () => Math.ceil(embeddedMinHeight());
+
+  const updateLayoutVariables = () => {
+    const header = document.getElementById("quarto-dashboard-header");
+    const headerHeight = header ? header.getBoundingClientRect().height : 0;
+
+    document.documentElement.style.setProperty(
+      "--dashboard-header-height",
+      `${Math.ceil(headerHeight)}px`
+    );
+  };
+
+  const applyEmbeddedLayoutStyles = () => {
+    if (!isDashboardEmbedded()) {
+      return;
+    }
+
+    [
+      document.documentElement,
+      document.body,
+      document.body && document.body.classList.contains("dashboard-fill")
+        ? document.body
+        : null,
+    ].forEach((element) => {
+      if (!element) {
+        return;
+      }
+
+      element.style.setProperty("height", "var(--dashboard-height)", "important");
+      element.style.setProperty("min-height", "var(--dashboard-embedded-min-height)", "important");
+      element.style.setProperty("max-height", "var(--dashboard-height)", "important");
+      element.style.setProperty("overflow", "hidden", "important");
+    });
+  };
+
+  const removeLegacySizingAttributes = () => {
+    [
+      document.documentElement,
+      document.body,
+      document.querySelector(".quarto-dashboard-content"),
+    ].forEach((element) => {
+      if (!element) {
+        return;
+      }
+
+      element.removeAttribute(SIZING_ATTRIBUTE);
+      element.removeAttribute("data-iframe-height");
+    });
+  };
+
+  const ensureSizingElement = () => {
+    if (!document.body) {
+      return null;
+    }
+
+    let element = document.getElementById(SIZING_ELEMENT_ID);
+
+    if (!element) {
+      element = document.createElement("div");
+      element.id = SIZING_ELEMENT_ID;
+      element.setAttribute("aria-hidden", "true");
+      document.body.appendChild(element);
+    }
+
+    element.setAttribute(SIZING_ATTRIBUTE, "");
+    element.style.cssText = [
+      "position:absolute",
+      "left:0",
+      "top:0",
+      "width:1px",
+      "height:var(--dashboard-height)",
+      "overflow:hidden",
+      "opacity:0",
+      "pointer-events:none",
+    ].join(";");
+
+    return element;
+  };
+
+  const parentIframeApi = () => window.parentIframe || window.parentIFrame;
+
+  const requestParentResize = () => {
+    if (!isDashboardEmbedded()) {
+      return;
+    }
+
+    const api = parentIframeApi();
+    if (!api) {
+      return;
+    }
+
+    try {
+      if (typeof api.setHeightCalculationMethod === "function") {
+        api.setHeightCalculationMethod("taggedElement");
+      }
+
+      if (typeof api.resize === "function") {
+        api.resize(embeddedDashboardHeight());
+      } else if (typeof api.size === "function") {
+        api.size(embeddedDashboardHeight());
+      }
+    } catch (error) {
+      // The parent API may not be ready during early page setup.
+    }
+  };
+
+  const requestParentResizeSoon = () => {
+    window.clearTimeout(resizeTimer);
+    resizeTimer = window.setTimeout(requestParentResize, RESIZE_DEBOUNCE_MS);
+  };
+
+  const markEmbedded = () => {
+    if (!isEmbedded()) {
+      return;
+    }
+
+    document.documentElement.classList.add(EMBEDDED_CLASS);
+    document.documentElement.style.setProperty(
+      "--dashboard-embedded-min-height",
+      `${EMBEDDED_MIN_HEIGHT}px`
+    );
+
+    if (document.body) {
+      document.body.classList.add(EMBEDDED_CLASS);
+    }
+
+    updateLayoutVariables();
+    applyEmbeddedLayoutStyles();
+    removeLegacySizingAttributes();
+    ensureSizingElement();
+    requestParentResizeSoon();
+  };
+
+  const previousConfig = window.iframeResizer || window.iFrameResizer || {};
+
+  const iframeResizerConfig = {
+    ...previousConfig,
+    heightCalculationMethod: "taggedElement",
+    sizeSelector: `#${SIZING_ELEMENT_ID}`,
+    onBeforeResize(height) {
+      let nextHeight = height;
+
+      if (typeof previousConfig.onBeforeResize === "function") {
+        const previousHeight = previousConfig.onBeforeResize.call(this, height);
+
+        if (Number.isFinite(previousHeight)) {
+          nextHeight = previousHeight;
+        }
+      }
+
+      if (!isDashboardEmbedded()) {
+        return nextHeight;
+      }
+
+      return embeddedDashboardHeight();
+    },
+    onReady(...args) {
+      if (typeof previousConfig.onReady === "function") {
+        previousConfig.onReady.call(this, ...args);
+      }
+
+      markEmbedded();
+      requestParentResize();
+    },
+  };
+
+  window.iframeResizer = iframeResizerConfig;
+  window.iFrameResizer = iframeResizerConfig;
+
+  markEmbedded();
+
+  document.addEventListener("DOMContentLoaded", markEmbedded);
+  window.addEventListener("load", markEmbedded);
+  window.addEventListener("resize", () => {
+    updateLayoutVariables();
+    applyEmbeddedLayoutStyles();
+    requestParentResizeSoon();
+  });
+
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", () => {
+      updateLayoutVariables();
+      applyEmbeddedLayoutStyles();
+      requestParentResizeSoon();
+    });
+  }
+})();

--- a/www/images/chart-area-custom.svg
+++ b/www/images/chart-area-custom.svg
@@ -1,11 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
   <path
-    d="M 6 14 L 6 10 L 10 10 L 14 4 L 18 4 L 18 14 Z"
+    d="M 2 13 L 2 9 L 6 9 L 10 3 L 14 3 L 14 13 Z"
     fill="currentColor"
     fill-opacity="0.15"
   />
   <path
-    d="M 6 10 L 10 10 L 14 4 L 18 4"
+    d="M 2 9 L 6 9 L 10 3 L 14 3"
     stroke="currentColor"
     stroke-width="1"
     fill="none"

--- a/www/images/chart-bar-custom.svg
+++ b/www/images/chart-bar-custom.svg
@@ -1,13 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
-  <!--
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
   <path
-    d="M2 2V18H20"
-    stroke="currentColor"
-    stroke-width="1"
-  />
-  -->
-  <path
-    d="M 6 14 V 10 M 10 14 V 6 M 14 14 V 8 M 18 14 V 4"
+    d="M 2 13 V 9 M 6 13 V 5 M 10 13 V 7 M 14 13 V 2.5"
     stroke="currentColor"
     stroke-width="1"
   />

--- a/www/images/chart-line-custom.svg
+++ b/www/images/chart-line-custom.svg
@@ -1,31 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
-  <!--
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
   <path
-    d="M2 2V18H20"
+    d="M 2 13 L 6 5 L 10 11 L 14 3"
     stroke="currentColor"
     stroke-width="1"
   />
-  -->
-  <path
-    d="M 6 14 L 10 6 L 14 12 L 18 4"
+  <circle
+    cx="6" 
+    cy="5" 
+    r="1.5" 
+    fill="white"
     stroke="currentColor"
     stroke-width="1"
   />
   <circle
     cx="10" 
-    cy="6" 
+    cy="11" 
     r="1.5" 
     fill="white"
     stroke="currentColor"
     stroke-width="1"
   />
-  <circle
-    cx="14" 
-    cy="12" 
-    r="1.5" 
-    fill="white"
-    stroke="currentColor"
-    stroke-width="1"
-  />
-
 </svg>

--- a/www/images/chart-sankey-custom.svg
+++ b/www/images/chart-sankey-custom.svg
@@ -1,19 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
   <path
-    d="M 6 7.33 H 10.33 L 13.67 4 H 18"
+    d="M 2 6.33 H 6.33 L 9.67 3 H 14"
     stroke="currentColor"
     stroke-width="1"
   />
   <path
-    d="M 6 10 H 18"
+    d="M 2 9 H 14"
     stroke="currentColor"
     stroke-width="1"
   />
   <path
-    d="M 6 10 H 10.33 L 13.67 13.33 H 18"
+    d="M 2 9 H 6.33 L 9.67 12.33 H 14"
     stroke="currentColor"
     stroke-width="1"
   />
 </svg>
-
-

--- a/www/multi-selectize-behaviour.js
+++ b/www/multi-selectize-behaviour.js
@@ -1,0 +1,291 @@
+(() => {
+  const ENHANCED_ATTR = "data-multi-selectize-enhanced";
+  const HOVER_FIX_ATTR = "data-selectize-hover-fix";
+  const KEYBOARD_ACTIVE_CLASS = "selectize-keyboard-active";
+  const DROPDOWN_CLASS = "multi-selectize-group-actions";
+  const HEADER_CLASS = "multi-selectize-group-header";
+  const BUTTON_CLASS = "multi-selectize-add-group";
+  const NAVIGATION_KEYS = new Set([
+    "ArrowDown",
+    "ArrowUp",
+    "End",
+    "Home",
+    "PageDown",
+    "PageUp",
+  ]);
+
+  const dropdownElement = (selectize) => (
+    selectize.$dropdown && selectize.$dropdown[0]
+  );
+
+  const enableKeyboardActiveState = (selectize) => {
+    const dropdown = dropdownElement(selectize);
+    if (dropdown) {
+      dropdown.classList.add(KEYBOARD_ACTIVE_CLASS);
+    }
+  };
+
+  const disableKeyboardActiveState = (selectize) => {
+    const dropdown = dropdownElement(selectize);
+    if (dropdown) {
+      dropdown.classList.remove(KEYBOARD_ACTIVE_CLASS);
+    }
+  };
+
+  const clearUnhoveredActiveOptions = (selectize) => {
+    const dropdown = dropdownElement(selectize);
+    if (!dropdown) {
+      return;
+    }
+
+    dropdown.querySelectorAll("[data-selectable].active, .option.active").forEach((option) => {
+      if (!option.matches(":hover")) {
+        option.classList.remove("active");
+      }
+    });
+  };
+
+  const keepActiveStateHoverBound = (selectize) => {
+    const dropdown = dropdownElement(selectize);
+    if (!dropdown || dropdown.hasAttribute(HOVER_FIX_ATTR)) {
+      return;
+    }
+
+    dropdown.setAttribute(HOVER_FIX_ATTR, "true");
+
+    dropdown.addEventListener("mouseleave", () => {
+      disableKeyboardActiveState(selectize);
+      clearUnhoveredActiveOptions(selectize);
+    });
+
+    dropdown.addEventListener("mousemove", (event) => {
+      disableKeyboardActiveState(selectize);
+
+      if (!event.target.closest("[data-selectable], .option")) {
+        clearUnhoveredActiveOptions(selectize);
+      }
+    });
+  };
+
+  const clearUnhoveredActiveOptionsSoon = (selectize) => {
+    window.requestAnimationFrame(() => {
+      clearUnhoveredActiveOptions(selectize);
+      window.requestAnimationFrame(() => clearUnhoveredActiveOptions(selectize));
+    });
+  };
+
+  const asArray = (value) => {
+    if (Array.isArray(value)) {
+      return value.map(String);
+    }
+
+    if (value === null || value === undefined || value === "") {
+      return [];
+    }
+
+    return [String(value)];
+  };
+
+  const optionBelongsToGroup = (option, groupValue, groupLabel, optgroupField) => {
+    const optionGroup = option && option[optgroupField];
+
+    if (Array.isArray(optionGroup)) {
+      return optionGroup.some((value) => (
+        String(value) === groupValue || String(value) === groupLabel
+      ));
+    }
+
+    return String(optionGroup) === groupValue || String(optionGroup) === groupLabel;
+  };
+
+  const optionValuesForGroup = (selectize, groupEl, groupLabel) => {
+    const groupValue = String(groupEl.getAttribute("data-group") || groupLabel);
+    const optgroupField = selectize.settings.optgroupField || "optgroup";
+    const values = Object.keys(selectize.options || {}).filter((value) => (
+      optionBelongsToGroup(selectize.options[value], groupValue, groupLabel, optgroupField)
+    ));
+
+    if (values.length) {
+      return values;
+    }
+
+    return Array.from(groupEl.querySelectorAll("[data-selectable][data-value], .option[data-value]"))
+      .map((optionEl) => optionEl.getAttribute("data-value"))
+      .filter(Boolean);
+  };
+
+  const syncShinyInput = (selectize) => {
+    selectize.refreshItems();
+    selectize.refreshOptions(false);
+
+    if (selectize.$input && selectize.$input.trigger) {
+      selectize.$input.trigger("change");
+    }
+  };
+
+  const addGroupOptions = (selectize, groupEl, groupLabel) => {
+    const selected = new Set(asArray(selectize.getValue()));
+    const values = optionValuesForGroup(selectize, groupEl, groupLabel)
+      .filter((value) => !selected.has(String(value)));
+
+    if (!values.length) {
+      return;
+    }
+
+    values.forEach((value) => {
+      selectize.addItem(value, true);
+    });
+
+    syncShinyInput(selectize);
+  };
+
+  const decorateGroupHeaders = (selectize) => {
+    const dropdown = selectize.$dropdown && selectize.$dropdown[0];
+    if (!dropdown) {
+      return;
+    }
+
+    dropdown.classList.add(DROPDOWN_CLASS);
+
+    dropdown.querySelectorAll(".optgroup").forEach((groupEl) => {
+      const header = groupEl.querySelector(".optgroup-header");
+      if (!header || header.querySelector(`.${BUTTON_CLASS}`)) {
+        return;
+      }
+
+      const groupLabel = header.textContent.trim();
+      header.classList.add(HEADER_CLASS);
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = BUTTON_CLASS;
+      button.textContent = "+";
+      button.title = `Add all ${groupLabel}`;
+      button.setAttribute("aria-label", `Add all ${groupLabel}`);
+
+      ["mousedown", "mouseup", "click"].forEach((eventName) => {
+        button.addEventListener(eventName, (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (eventName === "click") {
+            addGroupOptions(selectize, groupEl, groupLabel);
+          }
+        });
+      });
+
+      header.appendChild(button);
+    });
+  };
+
+  const resetDropdownScroll = (selectize) => {
+    const dropdownContent = (
+      selectize.$dropdown_content && selectize.$dropdown_content[0]
+    ) || (
+      selectize.$dropdown && selectize.$dropdown[0]
+    );
+
+    if (dropdownContent) {
+      dropdownContent.scrollTop = 0;
+    }
+  };
+
+  const observeDropdown = (selectize) => {
+    const dropdownContent = (
+      selectize.$dropdown_content && selectize.$dropdown_content[0]
+    ) || (
+      selectize.$dropdown && selectize.$dropdown[0]
+    );
+
+    if (!dropdownContent) {
+      return;
+    }
+
+    let pending = false;
+    const observer = new MutationObserver(() => {
+      if (pending) {
+        return;
+      }
+
+      pending = true;
+      window.requestAnimationFrame(() => {
+        pending = false;
+        decorateGroupHeaders(selectize);
+      });
+    });
+
+    observer.observe(dropdownContent, { childList: true, subtree: true });
+  };
+
+  const enhanceMultiSelect = (select) => {
+    if (!select || !select.multiple || select.hasAttribute(ENHANCED_ATTR)) {
+      return false;
+    }
+
+    const selectize = select.selectize;
+    if (!selectize || !selectize.$dropdown || !selectize.$dropdown.length) {
+      return false;
+    }
+
+    select.setAttribute(ENHANCED_ATTR, "true");
+    decorateGroupHeaders(selectize);
+    observeDropdown(selectize);
+    keepActiveStateHoverBound(selectize);
+
+    if (selectize.$control && selectize.$control[0]) {
+      selectize.$control[0].addEventListener("keydown", (event) => {
+        if (
+          NAVIGATION_KEYS.has(event.key) &&
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey
+        ) {
+          enableKeyboardActiveState(selectize);
+        }
+      }, true);
+    }
+
+    if (selectize.on) {
+      selectize.on("dropdown_open", () => {
+        disableKeyboardActiveState(selectize);
+        window.requestAnimationFrame(() => {
+          decorateGroupHeaders(selectize);
+          resetDropdownScroll(selectize);
+        });
+        clearUnhoveredActiveOptionsSoon(selectize);
+      });
+      selectize.on("type", () => {
+        window.requestAnimationFrame(() => decorateGroupHeaders(selectize));
+      });
+    }
+
+    return true;
+  };
+
+  const enhanceAllMultiSelects = () => {
+    document.querySelectorAll("select.shiny-input-select[multiple]").forEach((select) => {
+      enhanceMultiSelect(select);
+    });
+  };
+
+  const startEnhancementRetries = () => {
+    let attempts = 0;
+    const intervalId = window.setInterval(() => {
+      attempts += 1;
+      enhanceAllMultiSelects();
+      if (attempts >= 40) {
+        window.clearInterval(intervalId);
+      }
+    }, 150);
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    enhanceAllMultiSelects();
+    startEnhancementRetries();
+  });
+
+  document.addEventListener("shiny:connected", () => {
+    enhanceAllMultiSelects();
+    startEnhancementRetries();
+  });
+})();

--- a/www/selectize-dropdown-sizing.js
+++ b/www/selectize-dropdown-sizing.js
@@ -1,0 +1,100 @@
+(() => {
+  const ENHANCED_ATTR = "data-selectize-dropdown-sizing";
+  const PANEL_GAP = 0;
+
+  const sidebarPanelFor = (element) => (
+    element.closest(".sidebar > .html-fill-container, .sidebar > .html-fill-item")
+    || element.closest(".sidebar-content, .sidebar")
+  );
+
+  const dropdownContentFor = (selectize) => (
+    selectize.$dropdown_content && selectize.$dropdown_content[0]
+  ) || (
+    selectize.$dropdown && selectize.$dropdown[0]
+  );
+
+  const applyDropdownHeight = (selectize) => {
+    if (!selectize || !selectize.$control || !selectize.$control[0]) {
+      return;
+    }
+
+    const control = selectize.$control[0];
+    const dropdown = selectize.$dropdown && selectize.$dropdown[0];
+    const dropdownContent = dropdownContentFor(selectize);
+    const panel = sidebarPanelFor(control);
+
+    if (!dropdown || !dropdownContent || !panel) {
+      return;
+    }
+
+    const panelRect = panel.getBoundingClientRect();
+    const dropdownRect = dropdown.getBoundingClientRect();
+    const availableHeight = Math.floor(panelRect.bottom - dropdownRect.top - PANEL_GAP);
+    const maxHeight = Math.max(0, availableHeight);
+
+    dropdown.style.setProperty("--selectize-dropdown-max-height", `${maxHeight}px`);
+    dropdownContent.style.maxHeight = `${maxHeight}px`;
+  };
+
+  const applySoon = (selectize) => {
+    window.requestAnimationFrame(() => {
+      applyDropdownHeight(selectize);
+      window.requestAnimationFrame(() => applyDropdownHeight(selectize));
+    });
+  };
+
+  const enhanceSelect = (select) => {
+    if (!select || select.hasAttribute(ENHANCED_ATTR) || !select.selectize) {
+      return false;
+    }
+
+    const selectize = select.selectize;
+    if (!selectize.$control || !selectize.$control.length) {
+      return false;
+    }
+
+    select.setAttribute(ENHANCED_ATTR, "true");
+
+    if (selectize.on) {
+      selectize.on("dropdown_open", () => applySoon(selectize));
+      selectize.on("type", () => applySoon(selectize));
+      selectize.on("refresh_options", () => applySoon(selectize));
+    }
+
+    const panel = sidebarPanelFor(selectize.$control[0]);
+    if (panel) {
+      panel.addEventListener("scroll", () => applyDropdownHeight(selectize), { passive: true });
+    }
+
+    window.addEventListener("resize", () => applyDropdownHeight(selectize), { passive: true });
+    applySoon(selectize);
+    return true;
+  };
+
+  const enhanceAllSelects = () => {
+    document.querySelectorAll("select.shiny-input-select").forEach((select) => {
+      enhanceSelect(select);
+    });
+  };
+
+  const startEnhancementRetries = () => {
+    let attempts = 0;
+    const intervalId = window.setInterval(() => {
+      attempts += 1;
+      enhanceAllSelects();
+      if (attempts >= 40) {
+        window.clearInterval(intervalId);
+      }
+    }, 150);
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    enhanceAllSelects();
+    startEnhancementRetries();
+  });
+
+  document.addEventListener("shiny:connected", () => {
+    enhanceAllSelects();
+    startEnhancementRetries();
+  });
+})();

--- a/www/single-selectize-behaviour.js
+++ b/www/single-selectize-behaviour.js
@@ -1,6 +1,76 @@
 (() => {
   const ENHANCED_ATTR = "data-single-selectize-enhanced";
+  const HOVER_FIX_ATTR = "data-selectize-hover-fix";
+  const KEYBOARD_ACTIVE_CLASS = "selectize-keyboard-active";
+  const NAVIGATION_KEYS = new Set([
+    "ArrowDown",
+    "ArrowUp",
+    "End",
+    "Home",
+    "PageDown",
+    "PageUp",
+  ]);
   const TYPEAHEAD_RESET_MS = 700;
+
+  const dropdownElement = (selectize) => (
+    selectize.$dropdown && selectize.$dropdown[0]
+  );
+
+  const enableKeyboardActiveState = (selectize) => {
+    const dropdown = dropdownElement(selectize);
+    if (dropdown) {
+      dropdown.classList.add(KEYBOARD_ACTIVE_CLASS);
+    }
+  };
+
+  const disableKeyboardActiveState = (selectize) => {
+    const dropdown = dropdownElement(selectize);
+    if (dropdown) {
+      dropdown.classList.remove(KEYBOARD_ACTIVE_CLASS);
+    }
+  };
+
+  const clearUnhoveredActiveOptions = (selectize) => {
+    const dropdown = dropdownElement(selectize);
+    if (!dropdown) {
+      return;
+    }
+
+    dropdown.querySelectorAll("[data-selectable].active, .option.active").forEach((option) => {
+      if (!option.matches(":hover")) {
+        option.classList.remove("active");
+      }
+    });
+  };
+
+  const keepActiveStateHoverBound = (selectize) => {
+    const dropdown = dropdownElement(selectize);
+    if (!dropdown || dropdown.hasAttribute(HOVER_FIX_ATTR)) {
+      return;
+    }
+
+    dropdown.setAttribute(HOVER_FIX_ATTR, "true");
+
+    dropdown.addEventListener("mouseleave", () => {
+      disableKeyboardActiveState(selectize);
+      clearUnhoveredActiveOptions(selectize);
+    });
+
+    dropdown.addEventListener("mousemove", (event) => {
+      disableKeyboardActiveState(selectize);
+
+      if (!event.target.closest("[data-selectable], .option")) {
+        clearUnhoveredActiveOptions(selectize);
+      }
+    });
+  };
+
+  const clearUnhoveredActiveOptionsSoon = (selectize) => {
+    window.requestAnimationFrame(() => {
+      clearUnhoveredActiveOptions(selectize);
+      window.requestAnimationFrame(() => clearUnhoveredActiveOptions(selectize));
+    });
+  };
 
   const enhanceSingleSelect = (select) => {
     if (!select || select.multiple || select.hasAttribute(ENHANCED_ATTR)) {
@@ -34,6 +104,7 @@
 
     control.style.cursor = "pointer";
     syncInputState();
+    keepActiveStateHoverBound(selectize);
 
     const isDropdownOpen = () => (
       selectize.isOpen ||
@@ -83,7 +154,7 @@
     );
 
     const activeOptionValue = () => {
-      const dropdown = selectize.$dropdown && selectize.$dropdown[0];
+      const dropdown = dropdownElement(selectize);
       const activeOption = dropdown && dropdown.querySelector(
         "[data-selectable].active, [data-value].active"
       );
@@ -141,6 +212,8 @@
         } else {
           selectize.focus();
           selectize.open();
+          disableKeyboardActiveState(selectize);
+          clearUnhoveredActiveOptionsSoon(selectize);
         }
 
         window.requestAnimationFrame(syncInputState);
@@ -159,12 +232,18 @@
         return;
       }
 
+      if (NAVIGATION_KEYS.has(event.key)) {
+        enableKeyboardActiveState(selectize);
+        return;
+      }
+
       if (event.key.length !== 1) {
         return;
       }
 
       event.preventDefault();
       event.stopImmediatePropagation();
+      enableKeyboardActiveState(selectize);
       selectTypeaheadMatch(event.key.toLowerCase());
     }, true);
 


### PR DESCRIPTION
## Summary

This branch improves the dashboard filter experience by replacing flat selectize filter lists with grouped choices for end use, fuel, sector, and technology. Multi-select filters now show group headers with an “add all” action, making it easier to select related categories at once.

It also tightens the embedded dashboard layout by adding iframe-aware sizing behaviour, fixed dashboard height handling, sidebar scrolling improvements, and dynamic selectize dropdown sizing so filter menus fit within the available panel space.

Additional UI polish includes updated selectize hover/keyboard behaviour, refined chart type icons and alignment, and consistent black colouring for unknown categories in the EEUD colour palette.

## Main changes

- Add grouped filter choice generation in `index.qmd`
- Add group-level selection controls for multi-selectize dropdowns
- Add dynamic dropdown height sizing inside sidebar panels
- Improve single-selectize keyboard, hover, and typeahead behaviour
- Add embedded iframe layout and resize handling
- Update dashboard height/sidebar overflow styles
- Refresh chart toggle SVG icons and alignment
- Standardise `Unknown` palette colours to black
```