### PR TITLE
Filter enhancements

### DIFF
--- a/eeca.scss
+++ b/eeca.scss
@@ -437,6 +437,20 @@ shiny-data-frame {
     min-height: 0 !important;
 }
 
+.empty-data-message {
+    align-items: center !important;
+    color: $black !important;
+    display: flex !important;
+    font-size: 16px !important;
+    font-weight: $regular !important;
+    height: 100% !important;
+    justify-content: center !important;
+    min-height: 280px;
+    padding: 1rem;
+    text-align: center;
+    width: 100% !important;
+}
+
 /* Card shell */
 
 .card {
@@ -1024,6 +1038,14 @@ $slider-selected-color: $sky-blue-light;
 
 }
 
+.sidebar .cell-output-display:has(.selectize-input.dropdown-active),
+.sidebar .shiny-input-container:has(.selectize-input.dropdown-active),
+.sidebar .selectize-control:has(.selectize-input.dropdown-active) {
+    overflow: visible !important;
+    position: relative;
+    z-index: 1000 !important;
+}
+
 .selectize-control.multi .selectize-input > .item,
 .selectize-control.multi .selectize-input > div {
     align-items: stretch !important;
@@ -1160,6 +1182,7 @@ $slider-selected-color: $sky-blue-light;
 
 .multi-selectize-clear-container {
     position: relative;
+    transform: translateY(-4px) !important;
 
     > label.control-label,
     > label {
@@ -1266,6 +1289,7 @@ $slider-selected-color: $sky-blue-light;
     box-shadow: 0 0px 0px rgba($black, 0.15) !important;
     margin-top: 0 !important;
     top: 100% !important;
+    z-index: 1001 !important;
 }
 
 .selectize-dropdown .option {
@@ -1491,7 +1515,7 @@ shiny-data-frame [role="grid"]::-webkit-scrollbar-thumb {
 .js-plotly-plot .plotly .legendtitletext tspan,
 .js-plotly-plot .plotly g.legendtitle text {
     font-size: 14px !important;
-    font-weight: $bold !important;
+    font-weight: $medium !important;
 }
 
 .js-plotly-plot .plotly .sankey text,

--- a/eeca.scss
+++ b/eeca.scss
@@ -77,6 +77,7 @@ body {
     font-family: $font-family-sans-serif !important;
     //font-stretch: condensed !important;
     font-weight: $regular !important;
+    color: $black;
 
     &.quarto-dashboard.dashboard-fill {
         display: flex;
@@ -90,10 +91,12 @@ body {
 p {
     font-size: 16px !important;
     font-weight: $regular !important;
+    color: $black !important;
 }
 label {
     font-size: 16px !important;
     font-weight: $regular !important;
+    color: $black !important;
 }
 
 #quarto-dashboard-header {
@@ -174,7 +177,7 @@ label {
             min-height: 0 !important;
             overflow-x: hidden !important;
             overflow-y: auto !important;
-            padding: calc($def-padding * 2) $def-padding calc($def-padding * 2) calc($def-padding * 2) !important;
+            padding: calc($def-padding * 2) $def-padding calc($def-padding * 2) $def-padding !important;
             scrollbar-color: rgba($black, 0.25) $white;
         }
 
@@ -394,6 +397,15 @@ shiny-data-frame {
     }
 }
 
+.card-toolbar .cell-output-display:has(#render_explore_title),
+#render_explore_title {
+    display: contents !important;
+}
+
+#render_explore_title > .card-title {
+    margin-top: 0.1em;
+}
+
 .overview-toolbar {
     width: 100%;
 }
@@ -573,11 +585,13 @@ $slider-handle-dot-size: 8px;
 $slider-min-max-padding: 8px;
 $slider-selected-padding: 4px;
 $slider-track-color: $secondary;
-$slider-selected-color: $sky-blue;
+$slider-selected-color: $sky-blue-light;
 
 .irs {
+    box-sizing: border-box !important;
     display: block !important;
     margin: 0 !important;
+    max-width: 100% !important;
     width: 100% !important;
 }
 
@@ -611,7 +625,9 @@ $slider-selected-color: $sky-blue;
         background: $slider-selected-color !important;
         border-color: $slider-selected-color !important;
         border-radius: 0 !important;
-        color: $black !important;
+        color: $sea-blue !important;
+        font-size: 14px !important;
+        font-weight: $bold !important;
         padding: $slider-selected-padding !important;
         text-shadow: none !important;
         top: $slider-selected-label-top !important;
@@ -628,13 +644,23 @@ $slider-selected-color: $sky-blue;
 
     .irs-line {
         background: $slider-track-color !important;
+        cursor: default !important;
         height: 1px !important;
         top: $slider-track-top !important;
+
+        &::before {
+            cursor: default !important;
+        }
     }
 
     .irs-bar {
         background: $slider-selected-color !important;
+        cursor: default !important;
         top: $slider-track-top !important;
+
+        &::before {
+            cursor: default !important;
+        }
     }
 
     .irs-shadow {
@@ -648,7 +674,7 @@ $slider-selected-color: $sky-blue;
         border-radius: 50% !important;
         box-sizing: border-box !important;
         box-shadow: none !important;
-        cursor: pointer !important;
+        cursor: ew-resize !important;
         height: $slider-handle-size !important;
         top: $slider-handle-top !important;
         transform: none !important;
@@ -673,6 +699,17 @@ $slider-selected-color: $sky-blue;
     }
 }
 
+.sidebar .cell-output-display:has(.shiny-input-container > #explore_period),
+.sidebar .cell-output-display:has(.shiny-input-container > #data_period) {
+    overflow: visible !important;
+}
+
+.shiny-input-container:has(> #explore_period),
+.shiny-input-container:has(> #data_period) {
+    max-width: 100% !important;
+    min-width: 0 !important;
+}
+
 .shiny-input-container {
     &:has(> #explore_period) > .irs--shiny {
         .irs-line {
@@ -692,8 +729,18 @@ $slider-selected-color: $sky-blue;
 
         .irs-bar {
             background: $slider-selected-color !important;
+            cursor: grab !important;
             height: 4px !important;
             top: $slider-range-top !important;
+
+            &::before {
+                cursor: grab !important;
+            }
+
+            &:active,
+            &:active::before {
+                cursor: grabbing !important;
+            }
         }
     }
 }
@@ -786,7 +833,7 @@ $slider-selected-color: $sky-blue;
     line-height: 1 !important;
     margin-bottom: 0 !important;
     text-align: center !important;
-    transform: translateY(1px) !important;
+    //transform: translateY(-1px) !important;
     width: 1rem !important;
 }
 
@@ -884,10 +931,27 @@ $slider-selected-color: $sky-blue;
 
 .selectize-control.multi .selectize-input > .item,
 .selectize-control.multi .selectize-input > div {
-    background-color: $sky-blue !important;
-    color: black !important;
+    background-color: $sky-blue-light !important;
+    color: $sea-blue !important;
+    cursor: default !important;
+    font-size: 14px !important;
+    font-weight: $bold !important;
+}
+
+.selectize-control.multi .selectize-input > .item .remove,
+.selectize-control.multi .selectize-input > div .remove {
+    cursor: pointer !important;
     font-size: 16px !important;
-    font-weight: $regular !important;
+    font-weight: $bold !important;
+    margin-left: 0 !important;
+}
+
+.selectize-control.multi .selectize-input > .multi-selectize-hidden-group-item {
+    display: none !important;
+}
+
+.selectize-control.multi .selectize-input > .multi-selectize-group-item > .multi-selectize-group-item-remove {
+    display: inline-block !important;
 }
 
 .selectize-control.single .selectize-input > .item {
@@ -909,7 +973,7 @@ $slider-selected-color: $sky-blue;
 
 /* Replace only the single-select triangle */
 .selectize-control.single .selectize-input:not(.no-arrow):after {
-    content: "⌵" !important; /* "⌄" or "⌵", "▾", "˅" */
+    content: "\f078" !important;
     border: none !important;
     background: none !important;
     width: auto !important;
@@ -917,19 +981,20 @@ $slider-selected-color: $sky-blue;
     top: 50% !important;
     right: 12px !important;
     margin-top: 0 !important;
-    transform: translateY(-67%) !important;
-    font-size: 16px !important;
+    transform: translateY(-50%) !important;
+    font-family: "Font Awesome 7 Free", "Font Awesome 6 Free" !important;
+    font-size: 12px !important;
+    font-style: normal !important;
     line-height: 1 !important;
     color: black !important;
     pointer-events: none !important;
-    font-weight: bold !important;
+    font-weight: 900 !important;
     transition: transform 0.3s ease;
 }
 
 /* Open */
 .selectize-control.single .selectize-input.dropdown-active:not(.no-arrow):after {
-    font-weight: bold !important;
-    transform: translateY(-33%) scaleY(-1) !important;
+    transform: translateY(-50%) scaleY(-1) !important;
     transition: transform 0.3s ease;
 }
 
@@ -951,10 +1016,92 @@ $slider-selected-color: $sky-blue;
     width: 100% !important;
 }
 
+.selectize-control.multi .selectize-input.multi-selectize-add-placeholder.has-items > input {
+    max-width: 100% !important;
+    min-width: min(100%, 12.5rem) !important;
+    width: min(100%, 12.5rem) !important;
+    padding: calc($def-padding / 2) 0 $def-padding !important;
+}
+
 .selectize-input > input::placeholder {
     color: $control-placeholder !important;
     font-size: 16px !important;
     font-weight: $regular !important;
+}
+
+.selectize-control.multi .selectize-input > .clear {
+    display: none !important;
+}
+
+.multi-selectize-clear-container {
+    position: relative;
+
+    > label.control-label,
+    > label {
+        display: block;
+        padding-right: 4.75rem;
+    }
+}
+
+.multi-selectize-clear-button {
+    align-items: center;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    color: $black;
+    cursor: pointer;
+    display: none;
+    font-family: inherit;
+    font-size: 16px;
+    font-weight: $regular;
+    gap: 0.35rem;
+    height: 1.75rem;
+    min-width: 29px;
+    justify-content: center;
+    line-height: 1;
+    padding: 0 0.35rem;
+    position: absolute;
+    right: 0;
+    top: -0.25rem;
+    width: auto;
+}
+
+.multi-selectize-clear-label {
+    align-items: center;
+    display: inline-flex;
+    font-size: 14px;
+    font-weight: $medium;
+    //font-stretch: condensed;
+    height: 100%;
+    line-height: 1;
+}
+
+.multi-selectize-clear-button > i {
+    align-items: center;
+    display: inline-flex;
+    font-size: 12px;
+    height: 100%;
+    justify-content: center;
+    line-height: 1;
+    //transform: translateY(2px);
+}
+
+.multi-selectize-clear-button:not([hidden]),
+.multi-selectize-clear-container.has-multi-selectize-value > .multi-selectize-clear-button {
+    display: inline-flex;
+}
+
+.multi-selectize-clear-button[hidden] {
+    display: none !important;
+}
+
+.multi-selectize-clear-button:hover,
+.multi-selectize-clear-button:focus,
+.multi-selectize-clear-button:focus-visible {
+    background: $secondary;
+    color: $sea-blue;
+    outline: 0;
 }
 
 .form-select,
@@ -964,6 +1111,11 @@ $slider-selected-color: $sky-blue;
     border-bottom: 4px solid transparent !important;
     box-shadow: inset 0 -1px 0 $secondary !important;
     font-size: 16px !important;
+}
+
+.selectize-control.multi .selectize-input {
+    padding-left: $def-padding !important;
+    padding-right: $def-padding !important;
 }
 
 .form-select:focus,
@@ -1042,12 +1194,23 @@ $slider-selected-color: $sky-blue;
     width: 1.75rem;
 }
 
+.selectize-dropdown.multi-selectize-group-actions .multi-selectize-add-group > i {
+    align-items: center;
+    display: inline-flex;
+    font-size: 12.5px;
+    height: 100%;
+    justify-content: center;
+    line-height: 1;
+    transform: translateY(1px);
+}
+
 .selectize-dropdown.multi-selectize-group-actions .multi-selectize-add-group:hover,
 .selectize-dropdown.multi-selectize-group-actions .multi-selectize-add-group:focus,
 .selectize-dropdown.multi-selectize-group-actions .multi-selectize-add-group:focus-visible {
     background: $secondary;
-    outline: 0px solid $sky-blue;
-    outline-offset: 0px;
+    color: $sea-blue;
+    //outline: 0px solid $sky-blue;
+    //outline-offset: 0px;
 }
 
 .selectize-dropdown-content {
@@ -1062,7 +1225,7 @@ $slider-selected-color: $sky-blue;
 }
 
 .selectize-dropdown .option.selected {
-    background: $sky-blue !important;
+    background: $sky-blue-light !important;
     color: black !important;
 }
 
@@ -1075,7 +1238,7 @@ $slider-selected-color: $sky-blue;
 .selectize-control.single .selectize-dropdown .option.selected,
 .selectize-control.single .selectize-dropdown .option.selected:hover,
 .selectize-control.single .selectize-dropdown .option.selected.active {
-    background: $sky-blue !important;
+    background: $sky-blue-light !important;
     color: black !important;
 }
 
@@ -1176,34 +1339,43 @@ shiny-data-frame [role="grid"]::-webkit-scrollbar-thumb {
 
 
 h1 {
-    color: $primary !important;
+    color: $black !important;
     font-size: 28px !important;
     font-stretch: normal !important;
     font-weight: $bold !important;
 }
 h2 {
-    color: $primary !important;
+    color: $black !important;
     font-size: 24px !important;
     font-stretch: normal !important;
     font-weight: $bold !important;
 }
 h3 {
-    color: $primary !important;
+    color: $black !important;
     font-size: 20px !important;
     font-stretch: normal !important;
     font-weight: $bold !important;
 }
 h4 {
-    color: $primary !important;
+    color: $black !important;
     font-size: 18px !important;
     font-stretch: normal !important;
     font-weight: $bold !important;
 }
 h5 {
-    color: $primary !important;
+    color: $black !important;
     font-size: 16px !important;
     font-weight: $medium !important;
     font-stretch: normal !important;
+}
+
+.sidebar-section-title {
+    color: $black !important;
+    font-family: $font-family-sans-serif !important;
+    font-size: 16px !important;
+    font-stretch: normal !important;
+    font-weight: $medium !important;
+    margin: 0 0 calc(2 * $def-padding);
 }
 
 /* Plotly */
@@ -1305,4 +1477,9 @@ h5 {
     transform: translateY(-36%) !important;
     margin-right: 0 !important;
     padding-right: $def-padding !important;
+}
+
+
+.navbar .navbar-brand-container .navbar-title-text {
+    font-size: 50px !important;
 }

--- a/eeca.scss
+++ b/eeca.scss
@@ -1,5 +1,7 @@
 /*-- scss:defaults --*/
 
+/* Neutral colours */
+
 $white: #FFFFFF;
 $black: #000000;
 $silver: #FBFBFB;  // lighter grey
@@ -27,18 +29,23 @@ $primary: $black;
 $secondary: #C0EBEB;
 $control-placeholder: rgba($black, 0.5);
 
+/* Typography tokens */
+
 $bold: 700;
 $medium: 500;
 $regular: 400;
 
+$font-family-sans-serif: "National 2", sans-serif !default;
+
+/* Quarto and Bootstrap tokens */
+
 $navbar-bg: $silver !default;
 $navbar-fg: $primary !default;
 
-$font-family-sans-serif: "National 2", sans-serif !default;
 $def-padding: 0.375rem !default;
 $border-radius: 0 !default;
 
-/* Layout */
+/* Base page and typography */
 
 :root {
     --dashboard-embedded-min-height: 1000px;
@@ -88,16 +95,58 @@ body {
     }
 }
 
-p {
-    font-size: 16px !important;
-    font-weight: $regular !important;
-    color: $black !important;
-}
+p,
 label {
     font-size: 16px !important;
     font-weight: $regular !important;
     color: $black !important;
 }
+
+h1 {
+    color: $black !important;
+    font-size: 28px !important;
+    font-stretch: normal !important;
+    font-weight: $bold !important;
+}
+
+h2 {
+    color: $black !important;
+    font-size: 24px !important;
+    font-stretch: normal !important;
+    font-weight: $bold !important;
+}
+
+h3 {
+    color: $black !important;
+    font-size: 20px !important;
+    font-stretch: normal !important;
+    font-weight: $bold !important;
+}
+
+h4 {
+    color: $black !important;
+    font-size: 18px !important;
+    font-stretch: normal !important;
+    font-weight: $bold !important;
+}
+
+h5 {
+    color: $black !important;
+    font-size: 16px !important;
+    font-weight: $medium !important;
+    font-stretch: normal !important;
+}
+
+.sidebar-section-title {
+    color: $black !important;
+    font-family: $font-family-sans-serif !important;
+    font-size: 16px !important;
+    font-stretch: normal !important;
+    font-weight: $medium !important;
+    margin: 0 0 calc(2 * $def-padding);
+}
+
+/* Dashboard layout */
 
 #quarto-dashboard-header {
     flex: 0 0 auto;
@@ -379,7 +428,7 @@ label {
     }
 }
 
-/* Cards and containers */
+/* Cards, toolbars, and containers */
 
 .card,
 .card-body,
@@ -387,6 +436,8 @@ label {
 shiny-data-frame {
     min-height: 0 !important;
 }
+
+/* Card shell */
 
 .card {
     border: 0 !important;
@@ -416,6 +467,8 @@ shiny-data-frame {
     font-weight: $medium !important;
 }
 
+/* Toolbars */
+
 .toolbar {
     background-color: $silver !important;
     border: 0 !important;
@@ -435,6 +488,8 @@ shiny-data-frame {
 #render_explore_title > .card-title {
     margin-top: 0.1em;
 }
+
+/* Overview toolbar */
 
 .overview-toolbar {
     width: 100%;
@@ -493,6 +548,8 @@ shiny-data-frame {
         width: max-content !important;
     }
 }
+
+/* Container helpers */
 
 .borderless {
     border: 0 !important;
@@ -603,6 +660,8 @@ shiny-data-frame {
 .shiny-options-group {
     font-weight: $regular !important;
 }
+
+/* Sliders */
 
 $slider-height: 64px;
 $slider-label-size: 16px;
@@ -775,6 +834,8 @@ $slider-selected-color: $sky-blue-light;
     }
 }
 
+/* Buttons and actions */
+
 .btn {
     font-size: 16px !important;
     font-weight: $regular !important;
@@ -877,6 +938,8 @@ $slider-selected-color: $sky-blue-light;
     width: 100% !important;
 }
 
+/* Chart type toggles */
+
 #explore_bar,
 #explore_sankey,
 #timeseries_area,
@@ -945,6 +1008,8 @@ $slider-selected-color: $sky-blue-light;
         }
     }
 }
+
+/* Selectize controls */
 
 .shiny-input-select,
 .form-select,
@@ -1024,11 +1089,6 @@ $slider-selected-color: $sky-blue-light;
     color: black !important;
     font-size: 16px !important;
     font-weight: $regular !important;
-}
-
-.selectize-control.single .selectize-input > input {
-    caret-color: transparent !important;
-    color: transparent !important;
 }
 
 .selectize-control.single .selectize-input > input {
@@ -1408,46 +1468,6 @@ shiny-data-frame [role="grid"]::-webkit-scrollbar-thumb {
 }
 
 
-h1 {
-    color: $black !important;
-    font-size: 28px !important;
-    font-stretch: normal !important;
-    font-weight: $bold !important;
-}
-h2 {
-    color: $black !important;
-    font-size: 24px !important;
-    font-stretch: normal !important;
-    font-weight: $bold !important;
-}
-h3 {
-    color: $black !important;
-    font-size: 20px !important;
-    font-stretch: normal !important;
-    font-weight: $bold !important;
-}
-h4 {
-    color: $black !important;
-    font-size: 18px !important;
-    font-stretch: normal !important;
-    font-weight: $bold !important;
-}
-h5 {
-    color: $black !important;
-    font-size: 16px !important;
-    font-weight: $medium !important;
-    font-stretch: normal !important;
-}
-
-.sidebar-section-title {
-    color: $black !important;
-    font-family: $font-family-sans-serif !important;
-    font-size: 16px !important;
-    font-stretch: normal !important;
-    font-weight: $medium !important;
-    margin: 0 0 calc(2 * $def-padding);
-}
-
 /* Plotly */
 
 .js-plotly-plot .plotly,
@@ -1471,7 +1491,7 @@ h5 {
 .js-plotly-plot .plotly .legendtitletext tspan,
 .js-plotly-plot .plotly g.legendtitle text {
     font-size: 14px !important;
-    font-weight: $medium !important;
+    font-weight: $bold !important;
 }
 
 .js-plotly-plot .plotly .sankey text,
@@ -1547,9 +1567,4 @@ h5 {
     transform: translateY(-36%) !important;
     margin-right: 0 !important;
     padding-right: $def-padding !important;
-}
-
-
-.navbar .navbar-brand-container .navbar-title-text {
-    font-size: 50px !important;
 }

--- a/eeca.scss
+++ b/eeca.scss
@@ -152,21 +152,51 @@ label {
 }
 
 .bslib-sidebar-layout {
+    box-sizing: border-box;
+    isolation: isolate;
     max-height: 100%;
+    min-width: 0 !important;
+    position: relative;
+    width: 100%;
 
     > .main,
     .sidebar-content {
+        box-sizing: border-box;
         max-height: 100%;
+        max-width: 100%;
+        min-width: 0 !important;
         overflow: hidden;
+    }
+
+    > .main {
+        position: relative;
+        width: 100%;
+        z-index: 1;
+    }
+
+    .sidebar-content,
+    .sidebar-content > .bslib-grid,
+    .sidebar-content .bslib-grid > .html-fill-item,
+    .sidebar-content .card,
+    .sidebar-content .card-body,
+    .sidebar-content .cell-output-display,
+    .sidebar-content .shiny-ipywidget-output,
+    .sidebar-content shiny-data-frame {
+        max-width: 100% !important;
+        min-width: 0 !important;
     }
 
     .sidebar {
         background-color: $silver !important;
         border: 0 !important;
+        flex: 0 0 auto !important;
         height: 100% !important;
         max-height: 100%;
+        min-width: 0 !important;
         overflow: hidden !important;
         padding: 0 !important;
+        position: relative;
+        z-index: 2;
 
         > .html-fill-container,
         > .html-fill-item {
@@ -178,17 +208,17 @@ label {
             overflow-x: hidden !important;
             overflow-y: auto !important;
             padding: calc($def-padding * 2) $def-padding calc($def-padding * 2) $def-padding !important;
-            scrollbar-color: rgba($black, 0.25) $white;
+            scrollbar-color: rgba($black, 0.25) $silver;
         }
 
         > .html-fill-container::-webkit-scrollbar,
         > .html-fill-item::-webkit-scrollbar {
-            background: $white !important;
+            background: $silver !important;
         }
 
         > .html-fill-container::-webkit-scrollbar-track,
         > .html-fill-item::-webkit-scrollbar-track {
-            background: $white !important;
+            background: $silver !important;
         }
 
         > .html-fill-container::-webkit-scrollbar-thumb,
@@ -626,7 +656,7 @@ $slider-selected-color: $sky-blue-light;
         border-color: $slider-selected-color !important;
         border-radius: 0 !important;
         color: $sea-blue !important;
-        font-size: 14px !important;
+        font-size: 15px !important;
         font-weight: $bold !important;
         padding: $slider-selected-padding !important;
         text-shadow: none !important;
@@ -931,19 +961,54 @@ $slider-selected-color: $sky-blue-light;
 
 .selectize-control.multi .selectize-input > .item,
 .selectize-control.multi .selectize-input > div {
+    align-items: stretch !important;
     background-color: $sky-blue-light !important;
     color: $sea-blue !important;
     cursor: default !important;
-    font-size: 14px !important;
+    display: inline-flex !important;
+    font-size: 15px !important;
     font-weight: $bold !important;
+    line-height: 1 !important;
+    padding: 0 !important;
+}
+
+.selectize-control.multi .selectize-input > .item > .multi-selectize-item-label,
+.selectize-control.multi .selectize-input > div > .multi-selectize-item-label {
+    align-items: center !important;
+    display: inline-flex !important;
+    line-height: 1 !important;
+    padding: 5px 0 5px 7px !important;
 }
 
 .selectize-control.multi .selectize-input > .item .remove,
 .selectize-control.multi .selectize-input > div .remove {
+    align-items: center !important;
+    align-self: stretch !important;
+    border-radius: 0 !important;
     cursor: pointer !important;
+    display: inline-flex !important;
     font-size: 16px !important;
     font-weight: $bold !important;
-    margin-left: 0 !important;
+    height: auto !important;
+    justify-content: center !important;
+    line-height: 1 !important;
+    margin: 0 !important;
+    min-height: 0 !important;
+    padding-left: 0.45rem !important;
+    padding-right: 0.45rem !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    text-decoration: none !important;
+}
+
+.selectize-control.multi .selectize-input > .item .remove:hover,
+.selectize-control.multi .selectize-input > .item .remove:focus,
+.selectize-control.multi .selectize-input > .item .remove:focus-visible,
+.selectize-control.multi .selectize-input > div .remove:hover,
+.selectize-control.multi .selectize-input > div .remove:focus,
+.selectize-control.multi .selectize-input > div .remove:focus-visible {
+    background-color: rgba($white, 0.35) !important;
+    color: inherit !important;
 }
 
 .selectize-control.multi .selectize-input > .multi-selectize-hidden-group-item {
@@ -951,7 +1016,7 @@ $slider-selected-color: $sky-blue-light;
 }
 
 .selectize-control.multi .selectize-input > .multi-selectize-group-item > .multi-selectize-group-item-remove {
-    display: inline-block !important;
+    display: inline-flex !important;
 }
 
 .selectize-control.single .selectize-input > .item {
@@ -1146,6 +1211,11 @@ $slider-selected-color: $sky-blue-light;
 .selectize-dropdown .option {
     background: $white !important;
     color: black !important;
+}
+
+.selectize-dropdown.multi-selectize-group-actions .option {
+    font-size: 15px !important;
+    font-weight: $regular !important;
 }
 
 .selectize-dropdown .optgroup:before {

--- a/index.qmd
+++ b/index.qmd
@@ -1077,6 +1077,13 @@ def display_treemap():
         texttemplate="%{label}<br>%{value} TJ",
         textposition="middle center",
         branchvalues="total",
+        pathbar=dict(
+            thickness=24,
+            textfont=dict(
+                family=PLOTLY_FONT_FAMILY,
+                size=PLOTLY_FONT_SIZE,
+            )
+        ),
         hoverinfo="value",
         hovertemplate="%{label}<br>%{value} TJ<extra></extra>"
     )])

--- a/index.qmd
+++ b/index.qmd
@@ -19,7 +19,7 @@ format:
         - text: |
             <script async src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child@latest" type="text/javascript"></script>
         - text: |
-            <script src="www/slider-label-bounds.js"></script>
+            <script src="www/slider-label-bounds.js?v=20260617-1"></script>
         - text: |
             <script src="www/single-selectize-behaviour.js"></script>
         - text: |
@@ -1050,7 +1050,7 @@ def display_treemap():
 ## Row
 
 ### Column {.sidebar}
-<h5>Display</h5>
+<div class="sidebar-section-title" role="heading" aria-level="5">Display</div>
 
 ```{python}
 ui.input_selectize(
@@ -1068,7 +1068,7 @@ ui.input_selectize(
 ```
 
 <br/>
-<h5>Filter</h5>
+<div class="sidebar-section-title" role="heading" aria-level="5">Filter</div>
 
 ```{python}
 sectors_dict = {'Residential': ['All Residential', 'Residential', 'Residential Unallocated'],
@@ -1076,29 +1076,25 @@ sectors_dict = {'Residential': ['All Residential', 'Residential', 'Residential U
 
 ui.input_selectize('explore_end_use', "End Use", end_uses_selectize_choices, multiple=True,
     options={
-        'placeholder': "All End Uses",
-        'plugins': ['clear_button']
+        'placeholder': "All End Uses"
     }
 )
 
 ui.input_selectize('explore_fuels', "Fuel Type", fuels_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Fuel Types",
-        'plugins': ['clear_button']
+        'placeholder': "All Fuel Types"
     }
 )
 
 ui.input_selectize('explore_sectors', "Sector", sectors_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Sectors",
-        'plugins': ['clear_button']
+        'placeholder': "All Sectors"
     }
 )
 
 ui.input_selectize('explore_technologies', "Technology", technologies_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Technologies",
-        'plugins': ['clear_button']
+        'placeholder': "All Technologies"
     }
 ) 
 
@@ -1129,7 +1125,7 @@ def explore_eeud_filtered():
 ```
 
 <br/>
-<h5>Data View</h5>
+<div class="sidebar-section-title" role="heading" aria-level="5">Data View</div>
 
 ```{python}
 @render.download(
@@ -1152,6 +1148,13 @@ async def download_explore_filtered_data():
 # https://github.com/posit-dev/py-shiny/issues/973
 
 @render.ui
+def render_explore_title():
+    return ui.tags.div(
+        ui.tags.span(f"Energy Usage for {input.explore_period()}", style="display: inline"),
+        class_="card-title html-fill-item html-fill-container"
+    )
+
+@render.ui
 def render_bar_button():
     btn_class = 'btn-primary' if explore_chart_type.get() == 'Bar' else 'btn-secondary'
     return ui.input_action_button(
@@ -1159,6 +1162,7 @@ def render_bar_button():
         chart_type_button_label("bar", "Bar"),
         class_=btn_class
     )
+
 @reactive.effect
 def set_explore_bar_chart():
     input.explore_bar()
@@ -1175,6 +1179,7 @@ def render_sankey_button():
         chart_type_button_label("sankey", "Sankey"),
         class_=btn_class
     )
+
 @reactive.effect
 def set_explore_sankey_chart():
     input.explore_sankey()
@@ -1186,8 +1191,6 @@ def set_explore_sankey_chart():
 ```
 
 ```{python}
-#| title: Stationary Energy Usage
-
 # Initialize a reactive value
 explore_chart_type = reactive.value('Sankey')
 
@@ -1265,7 +1268,7 @@ def display_explore_chart():
 
 ### Column {.sidebar}
 
-<h5>Display</h5>
+<div class="sidebar-section-title" role="heading" aria-level="5">Display</div>
 
 ```{python}
 ui.input_selectize(
@@ -1283,35 +1286,31 @@ ui.input_selectize(
 ```
 
 <br/>
-<h5>Filter</h5>
+<div class="sidebar-section-title" role="heading" aria-level="5">Filter</div>
 
 ```{python}
 
 ui.input_selectize('timeseries_end_use', "End Use", end_uses_selectize_choices, multiple=True,
     options={
-        'placeholder': "All End Uses",
-        'plugins': ['clear_button']
+        'placeholder': "All End Uses"
     }
 )
 
 ui.input_selectize('timeseries_fuels', "Fuel Type", fuels_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Fuel Types",
-        'plugins': ['clear_button']
+        'placeholder': "All Fuel Types"
     }
 )
 
 ui.input_selectize('timeseries_sectors', "Sector", sectors_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Sectors",
-        'plugins': ['clear_button']
+        'placeholder': "All Sectors"
     }
 )
 
 ui.input_selectize('timeseries_technologies', "Technology", technologies_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Technologies",
-        'plugins': ['clear_button']
+        'placeholder': "All Technologies"
     }
 )
 
@@ -1335,7 +1334,7 @@ def timeseries_eeud_filtered():
 ```
 
 <br/>
-<h5>Data View</h5>
+<div class="sidebar-section-title" role="heading" aria-level="5">Data View</div>
 
 ```{python}
 @render.download(
@@ -1500,34 +1499,30 @@ def display_timeseries_chart():
 
 ### Column {.sidebar}
 
-<h5>Filter</h5>
+<div class="sidebar-section-title" role="heading" aria-level="5">Filter</div>
 
 ```{python}
 ui.input_selectize('data_end_use', "End Use", end_uses_selectize_choices, multiple=True,
     options={
-        'placeholder': "All End Uses",
-        'plugins': ['clear_button']
+        'placeholder': "All End Uses"
     }
 )
 
 ui.input_selectize('data_fuels', "Fuel Type", fuels_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Fuel Types",
-        'plugins': ['clear_button']
+        'placeholder': "All Fuel Types"
     }
 )
 
 ui.input_selectize('data_sectors', "Sector", sectors_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Sectors",
-        'plugins': ['clear_button']
+        'placeholder': "All Sectors"
     }
 )
 
 ui.input_selectize('data_technologies', "Technology", technologies_selectize_choices, multiple=True,
     options={
-        'placeholder': "All Technologies",
-        'plugins': ['clear_button']
+        'placeholder': "All Technologies"
     }
 ) 
 
@@ -1559,7 +1554,7 @@ def data_eeud_filtered():
 ```
 
 <br/>
-<h5>Data View</h5>
+<div class="sidebar-section-title" role="heading" aria-level="5">Data View</div>
 
 ```{python}
 @render.download(

--- a/index.qmd
+++ b/index.qmd
@@ -213,6 +213,8 @@ PLOTLY_AXIS_TITLE_SIZE = 14
 PLOTLY_LEGEND_TITLE_SIZE = 14
 PLOTLY_FONT_COLOR_LIGHT = "#000000"
 PLOTLY_FONT_COLOR_DARK = "#FFFFFF"
+EMPTY_DATA_MESSAGE = "There is no data to display for the applied filters."
+EMPTY_DATA_FONT_SIZE = 16
 
 def slugify_download_title(title):
     return re.sub(r"[^a-z0-9]+", "-", str(title).strip().lower()).strip("-")
@@ -233,6 +235,55 @@ def set_plotly_download_filename(fig, title):
         },
     }
     return widget
+
+def empty_data_message():
+    return ui.div(EMPTY_DATA_MESSAGE, class_="empty-data-message")
+
+def empty_data_figure(title):
+    fig = go.Figure()
+    fig.update_layout(
+        annotations=[
+            dict(
+                text=(
+                    f"<span style='font-size: {EMPTY_DATA_FONT_SIZE}px; "
+                    f"font-weight: 400;'>{EMPTY_DATA_MESSAGE}</span>"
+                ),
+                x=0.5,
+                y=0.5,
+                xref="paper",
+                yref="paper",
+                showarrow=False,
+                font=dict(
+                    family=PLOTLY_FONT_FAMILY,
+                    size=EMPTY_DATA_FONT_SIZE,
+                    color=PLOTLY_FONT_COLOR_LIGHT,
+                ),
+                xanchor="center",
+                yanchor="middle",
+            )
+        ],
+        dragmode=False,
+        font=dict(family=PLOTLY_FONT_FAMILY, size=EMPTY_DATA_FONT_SIZE),
+        margin=dict(l=0, r=0, t=0, b=0),
+        paper_bgcolor="rgba(255,255,255,255)",
+        plot_bgcolor="rgba(255,255,255,255)",
+        showlegend=False,
+        xaxis=dict(
+            fixedrange=True,
+            showgrid=False,
+            showticklabels=False,
+            visible=False,
+            zeroline=False,
+        ),
+        yaxis=dict(
+            fixedrange=True,
+            showgrid=False,
+            showticklabels=False,
+            visible=False,
+            zeroline=False,
+        ),
+    )
+    return set_plotly_download_filename(fig, title)
 
 def csv_download_filename(title):
     return f"{slugify_download_title(title) or 'eeud-data'}.csv"
@@ -1133,7 +1184,7 @@ def explore_eeud_filtered():
 @render.download(
     label=download_button_label("Download Chart Data"),
     filename=lambda: csv_download_filename(
-        f"Stationary Energy Usage {input.explore_left_node()} by {input.explore_right_node()} {input.explore_period()}"
+        f"Energy Usage for {input.explore_period()} - {input.explore_left_node()} by {input.explore_right_node()}"
     )
 )
 async def download_explore_filtered_data():
@@ -1178,7 +1229,7 @@ def render_sankey_button():
     btn_class = 'btn-primary' if explore_chart_type.get() == 'Sankey' else 'btn-secondary'
     return ui.input_action_button(
         "explore_sankey",
-        chart_type_button_label("sankey", "Sankey"),
+        chart_type_button_label("sankey", "Alluvial"),
         class_=btn_class
     )
 
@@ -1201,12 +1252,19 @@ def display_explore_chart():
     left_node = title_case(input.explore_left_node())
     right_node = title_case(input.explore_right_node())
     explore_df = explore_eeud_filtered()
+    chart_title = f"Stationary Energy Usage {left_node} to {right_node} {input.explore_period()}"
+
+    if explore_df.empty:
+        return empty_data_figure(chart_title)
     
     if left_node == right_node:
         explore_df['Proxy'] = 'Total Energy Use'
         right_node = 'Proxy'
 
     explore_df = explore_df.groupby([left_node, right_node]).sum(numeric_only=True).reset_index(drop=False)
+
+    if explore_df.empty:
+        return empty_data_figure(chart_title)
 
     if explore_chart_type.get() == 'Sankey':
         
@@ -1342,7 +1400,7 @@ def timeseries_eeud_filtered():
 @render.download(
     label=download_button_label("Download Chart Data"),
     filename=lambda: csv_download_filename(
-        f"Energy Usage Time Series {input.timeseries_category()} {input.timeseries_display()}"
+        f"Energy Usage Time Series - {input.timeseries_category()} {input.timeseries_display()}"
     )
 )
 async def download_timeseries_filtered_data():
@@ -1398,7 +1456,17 @@ timeseries_chart_type = reactive.value('Line')
 @render_widget
 def display_timeseries_chart():
     category = title_case(input.timeseries_category())
-    timeseries_df = timeseries_eeud_filtered().groupby([category, 'Period']).sum(numeric_only=True).reset_index(drop=False)
+    filtered_df = timeseries_eeud_filtered()
+    chart_title = f"Energy Usage Time Series {category} {input.timeseries_display()}"
+
+    if filtered_df.empty:
+        return empty_data_figure(chart_title)
+
+    timeseries_df = filtered_df.groupby([category, 'Period']).sum(numeric_only=True).reset_index(drop=False)
+
+    if timeseries_df.empty:
+        return empty_data_figure(chart_title)
+
     total = True
     if input.timeseries_display() == "Proportional":
         total = False
@@ -1407,7 +1475,7 @@ def display_timeseries_chart():
         timeseries_df['TJ'] = (timeseries_df['TJ'] / timeseries_df['TotalTJ']) * 100
 
     if timeseries_chart_type.get() == 'Alluvial':
-        timeseries_links, timeseries_nodes = create_alluvial_links_for_dict(timeseries_eeud_filtered(), category, 'PeriodEndDate')
+        timeseries_links, timeseries_nodes = create_alluvial_links_for_dict(filtered_df, category, 'PeriodEndDate')
         fig = go.Figure(data=[go.Sankey(
             arrangement="fixed",
             node = dict(
@@ -1572,9 +1640,21 @@ async def download_data_filtered_data():
 
 ### Column
 
-```{python} 
+```{python}
+#| include: false
 @render.data_frame
-def dataview():
+def dataview_grid():
     data = build_data_grid_download_data()
     return render.DataGrid(data, width="100%", summary=False)
+```
+
+```{python} 
+@render.ui
+def dataview():
+    data = data_eeud_filtered()
+
+    if data.empty:
+        return empty_data_message()
+
+    return ui.output_data_frame("dataview_grid")
 ```

--- a/index.qmd
+++ b/index.qmd
@@ -3,6 +3,7 @@ title: "Energy End Use Database"
 #logo: "https://eecagovtnz.sharepoint.com/SiteAssets/__rectSitelogo__Only%20EECA%20white.png"
 resources:
   - www/
+  - data/eeud-colour-palette-2026.csv
 format: 
   dashboard:
     theme: "eeca.scss"
@@ -22,6 +23,8 @@ format:
             <script src="www/slider-label-bounds.js?v=20260617-1"></script>
         - text: |
             <script src="www/single-selectize-behaviour.js"></script>
+        - text: |
+            <script src="www/selectize-colours.js"></script>
         - text: |
             <script src="www/multi-selectize-behaviour.js"></script>
         - text: |
@@ -152,7 +155,6 @@ end_uses_selectize_choices = grouped_selectize_choices(eeud, 'EndUseGroup', 'End
 fuels_selectize_choices = grouped_selectize_choices(eeud, 'FuelGroup', 'Fuel')
 sectors_selectize_choices = grouped_selectize_choices(eeud, 'SectorGroup', 'Sector')
 technologies_selectize_choices = technology_selectize_choices(eeud)
-
 ```
 
 ```{python}

--- a/www/multi-selectize-behaviour.js
+++ b/www/multi-selectize-behaviour.js
@@ -5,6 +5,15 @@
   const DROPDOWN_CLASS = "multi-selectize-group-actions";
   const HEADER_CLASS = "multi-selectize-group-header";
   const BUTTON_CLASS = "multi-selectize-add-group";
+  const CLEAR_CONTAINER_CLASS = "multi-selectize-clear-container";
+  const CLEAR_BUTTON_CLASS = "multi-selectize-clear-button";
+  const CLEAR_ACTIVE_CLASS = "has-multi-selectize-value";
+  const ADD_PLACEHOLDER_CLASS = "multi-selectize-add-placeholder";
+  const ADD_PLACEHOLDER_TEXT = "Click to add more filters";
+  const GROUP_ITEM_CLASS = "multi-selectize-group-item";
+  const GROUP_ITEM_REMOVE_CLASS = "multi-selectize-group-item-remove";
+  const HIDDEN_GROUP_ITEM_CLASS = "multi-selectize-hidden-group-item";
+  const CLOSE_SUPPRESSION_MS = 350;
   const NAVIGATION_KEYS = new Set([
     "ArrowDown",
     "ArrowUp",
@@ -121,6 +130,9 @@
     if (selectize.$input && selectize.$input.trigger) {
       selectize.$input.trigger("change");
     }
+
+    updateAddMorePlaceholderSoon(selectize);
+    updateCollapsedGroupItemsSoon(selectize);
   };
 
   const addGroupOptions = (selectize, groupEl, groupLabel) => {
@@ -137,6 +149,301 @@
     });
 
     syncShinyInput(selectize);
+  };
+
+  const labelForSelect = (select, container) => {
+    if (!container) {
+      return null;
+    }
+
+    return Array.from(container.querySelectorAll("label")).find((label) => (
+      label.getAttribute("for") === select.id
+    )) || container.querySelector("label.control-label, label");
+  };
+
+  const hasSelectedItems = (selectize) => asArray(selectize.getValue()).length > 0;
+
+  const controlInputFor = (selectize) => (
+    (selectize.$control_input && selectize.$control_input[0]) ||
+    (selectize.$control && selectize.$control[0] && selectize.$control[0].querySelector("input"))
+  );
+
+  const inputHasSearchText = (input) => Boolean(input && input.value.length > 0);
+
+  const suppressKeyboardEvent = (event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  const optionGroupValues = (option, optgroupField) => {
+    const optionGroup = option && option[optgroupField];
+
+    if (Array.isArray(optionGroup)) {
+      return optionGroup.map(String);
+    }
+
+    if (optionGroup === null || optionGroup === undefined || optionGroup === "") {
+      return [];
+    }
+
+    return [String(optionGroup)];
+  };
+
+  const groupLabelFor = (selectize, groupValue) => {
+    const optgroup = selectize.optgroups && selectize.optgroups[groupValue];
+    const label = optgroup && (optgroup.label || optgroup.text || optgroup.value);
+    return String(label || groupValue);
+  };
+
+  const selectedGroupSummaries = (selectize) => {
+    const optgroupField = selectize.settings.optgroupField || "optgroup";
+    const selectedValues = new Set(asArray(selectize.getValue()));
+    const groups = new Map();
+
+    Object.keys(selectize.options || {}).forEach((value) => {
+      const option = selectize.options[value];
+      optionGroupValues(option, optgroupField).forEach((groupValue) => {
+        if (!groups.has(groupValue)) {
+          groups.set(groupValue, {
+            label: groupLabelFor(selectize, groupValue),
+            values: [],
+          });
+        }
+
+        groups.get(groupValue).values.push(String(value));
+      });
+    });
+
+    return Array.from(groups.entries())
+      .map(([groupValue, group]) => ({
+        groupValue,
+        label: group.label,
+        values: group.values,
+      }))
+      .filter((group) => (
+        group.values.length > 1 &&
+        group.values.every((value) => selectedValues.has(String(value)))
+      ));
+  };
+
+  const selectedItemElements = (selectize) => {
+    const control = selectize.$control && selectize.$control[0];
+
+    if (!control) {
+      return [];
+    }
+
+    return Array.from(control.querySelectorAll("[data-value]")).filter((item) => (
+      !item.classList.contains(GROUP_ITEM_CLASS)
+    ));
+  };
+
+  const selectedItemElementForValue = (selectize, value) => (
+    selectedItemElements(selectize).find((item) => (
+      String(item.getAttribute("data-value")) === String(value)
+    ))
+  );
+
+  const removeCollapsedGroup = (selectize, values) => {
+    values.forEach((value) => {
+      selectize.removeItem(value, true);
+    });
+
+    syncShinyInput(selectize);
+    updateCollapsedGroupItemsSoon(selectize);
+  };
+
+  const buildCollapsedGroupItem = (selectize, group) => {
+    const item = document.createElement("div");
+    const label = document.createElement("span");
+    const remove = document.createElement("a");
+
+    item.className = `${GROUP_ITEM_CLASS} item`;
+    item.setAttribute("data-value", `__group__${group.groupValue}`);
+    item.setAttribute("data-multi-selectize-group", group.groupValue);
+    label.textContent = `All ${group.label}`;
+
+    remove.className = `${GROUP_ITEM_REMOVE_CLASS} remove`;
+    remove.href = "javascript:void(0)";
+    remove.tabIndex = -1;
+    remove.title = "Remove";
+    remove.setAttribute("aria-label", `Remove all ${group.label}`);
+    remove.textContent = "\u00d7";
+
+    ["mousedown", "mouseup", "click"].forEach((eventName) => {
+      remove.addEventListener(eventName, (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (eventName === "click") {
+          removeCollapsedGroup(selectize, group.values);
+        }
+      });
+    });
+
+    item.appendChild(label);
+    item.appendChild(remove);
+    return item;
+  };
+
+  const updateCollapsedGroupItems = (selectize) => {
+    const control = selectize.$control && selectize.$control[0];
+
+    if (!control) {
+      return;
+    }
+
+    control.querySelectorAll(`.${GROUP_ITEM_CLASS}`).forEach((item) => item.remove());
+    control.querySelectorAll(`.${HIDDEN_GROUP_ITEM_CLASS}`).forEach((item) => {
+      item.classList.remove(HIDDEN_GROUP_ITEM_CLASS);
+    });
+
+    selectedGroupSummaries(selectize).forEach((group) => {
+      const itemElements = group.values
+        .map((value) => selectedItemElementForValue(selectize, value))
+        .filter(Boolean);
+
+      if (!itemElements.length) {
+        return;
+      }
+
+      const groupItem = buildCollapsedGroupItem(selectize, group);
+      itemElements[0].insertAdjacentElement("beforebegin", groupItem);
+      itemElements.forEach((item) => {
+        item.classList.add(HIDDEN_GROUP_ITEM_CLASS);
+      });
+    });
+  };
+
+  const updateCollapsedGroupItemsSoon = (selectize) => {
+    window.requestAnimationFrame(() => {
+      updateCollapsedGroupItems(selectize);
+      window.requestAnimationFrame(() => updateCollapsedGroupItems(selectize));
+    });
+  };
+
+  const updateAddMorePlaceholder = (selectize) => {
+    const control = selectize.$control && selectize.$control[0];
+    const input = controlInputFor(selectize);
+
+    if (!control || !input) {
+      return;
+    }
+
+    const hasValue = hasSelectedItems(selectize);
+    control.classList.toggle(ADD_PLACEHOLDER_CLASS, hasValue);
+
+    if (hasValue) {
+      input.setAttribute("placeholder", ADD_PLACEHOLDER_TEXT);
+      return;
+    }
+
+    const emptyPlaceholder = selectize.settings && selectize.settings.placeholder;
+    if (emptyPlaceholder) {
+      input.setAttribute("placeholder", emptyPlaceholder);
+    } else {
+      input.removeAttribute("placeholder");
+    }
+  };
+
+  const updateAddMorePlaceholderSoon = (selectize) => {
+    window.requestAnimationFrame(() => {
+      updateAddMorePlaceholder(selectize);
+      window.requestAnimationFrame(() => updateAddMorePlaceholder(selectize));
+    });
+  };
+
+  const addSelectedPlaceholder = (selectize) => {
+    updateAddMorePlaceholderSoon(selectize);
+
+    if (selectize.on) {
+      [
+        "change",
+        "clear",
+        "dropdown_open",
+        "item_add",
+        "item_remove",
+        "type",
+      ].forEach((eventName) => {
+        selectize.on(eventName, () => updateAddMorePlaceholderSoon(selectize));
+      });
+    }
+  };
+
+  const addCollapsedGroupItems = (selectize) => {
+    updateCollapsedGroupItemsSoon(selectize);
+
+    if (selectize.on) {
+      [
+        "change",
+        "clear",
+        "item_add",
+        "item_remove",
+      ].forEach((eventName) => {
+        selectize.on(eventName, () => updateCollapsedGroupItemsSoon(selectize));
+      });
+    }
+  };
+
+  const updateClearButton = (container, button, selectize) => {
+    const hasValue = hasSelectedItems(selectize);
+    container.classList.toggle(CLEAR_ACTIVE_CLASS, hasValue);
+    button.hidden = !hasValue;
+  };
+
+  const addHeaderClearButton = (select, selectize) => {
+    const container = select.closest(".shiny-input-container");
+    const label = labelForSelect(select, container);
+
+    if (!container || !label) {
+      return;
+    }
+
+    container.classList.add(CLEAR_CONTAINER_CLASS);
+
+    let button = Array.from(container.children).find((child) => (
+      child.classList && child.classList.contains(CLEAR_BUTTON_CLASS)
+    ));
+    if (!button) {
+      const labelText = label.textContent.trim() || "filter";
+      const clearText = document.createElement("span");
+      const icon = document.createElement("i");
+
+      button = document.createElement("button");
+      button.type = "button";
+      button.className = CLEAR_BUTTON_CLASS;
+      button.title = `Clear ${labelText}`;
+      button.setAttribute("aria-label", `Clear ${labelText}`);
+      clearText.className = "multi-selectize-clear-label";
+      clearText.textContent = "CLEAR";
+      icon.className = "fa-solid fa-xmark";
+      icon.setAttribute("aria-hidden", "true");
+      //button.appendChild(clearText);
+      button.appendChild(icon);
+
+      ["mousedown", "mouseup", "click"].forEach((eventName) => {
+        button.addEventListener(eventName, (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (eventName === "click") {
+            selectize.clear(true);
+            syncShinyInput(selectize);
+            updateClearButton(container, button, selectize);
+          }
+        });
+      });
+
+      label.insertAdjacentElement("afterend", button);
+    }
+
+    updateClearButton(container, button, selectize);
+
+    if (selectize.on) {
+      selectize.on("change", () => updateClearButton(container, button, selectize));
+      selectize.on("item_add", () => updateClearButton(container, button, selectize));
+      selectize.on("item_remove", () => updateClearButton(container, button, selectize));
+    }
   };
 
   const decorateGroupHeaders = (selectize) => {
@@ -157,11 +464,14 @@
       header.classList.add(HEADER_CLASS);
 
       const button = document.createElement("button");
+      const icon = document.createElement("i");
       button.type = "button";
       button.className = BUTTON_CLASS;
-      button.textContent = "+";
       button.title = `Add all ${groupLabel}`;
       button.setAttribute("aria-label", `Add all ${groupLabel}`);
+      icon.className = "fa-solid fa-plus";
+      icon.setAttribute("aria-hidden", "true");
+      button.appendChild(icon);
 
       ["mousedown", "mouseup", "click"].forEach((eventName) => {
         button.addEventListener(eventName, (event) => {
@@ -217,6 +527,118 @@
     observer.observe(dropdownContent, { childList: true, subtree: true });
   };
 
+  const isDropdownOpen = (selectize, control) => (
+    selectize.isOpen ||
+    control.classList.contains("dropdown-active") ||
+    Boolean(selectize.$dropdown && selectize.$dropdown.is(":visible"))
+  );
+
+  const setControlCursor = (selectize, control, cursor) => {
+    const input = controlInputFor(selectize);
+    control.style.cursor = cursor;
+
+    if (input) {
+      input.style.cursor = cursor;
+    }
+  };
+
+  const updateOpenCursor = (selectize, control) => {
+    setControlCursor(
+      selectize,
+      control,
+      isDropdownOpen(selectize, control) ? "pointer" : ""
+    );
+  };
+
+  const suppressControlEvent = (event) => {
+    if (event.target.closest(".selectize-dropdown")) {
+      return false;
+    }
+
+    if (event.target.closest(".remove, button, a, [role='button']")) {
+      return false;
+    }
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    return true;
+  };
+
+  const closeDropdownFromControl = (selectize, control) => {
+    selectize.close();
+    selectize.blur();
+
+    const input = controlInputFor(selectize);
+    if (input) {
+      input.blur();
+    }
+
+    updateOpenCursor(selectize, control);
+  };
+
+  const addControlToggleBehaviour = (selectize) => {
+    const control = selectize.$control && selectize.$control[0];
+    if (!control) {
+      return;
+    }
+
+    let pendingMouseRelease = false;
+    let suppressUntil = 0;
+    const shouldSuppressFollowUp = () => window.performance.now() < suppressUntil;
+
+    updateOpenCursor(selectize, control);
+
+    control.addEventListener(
+      "mousedown",
+      (event) => {
+        pendingMouseRelease = suppressControlEvent(event);
+      },
+      true
+    );
+
+    control.addEventListener(
+      "mouseup",
+      (event) => {
+        if (!pendingMouseRelease || !suppressControlEvent(event)) {
+          pendingMouseRelease = false;
+          return;
+        }
+
+        pendingMouseRelease = false;
+        suppressUntil = window.performance.now() + CLOSE_SUPPRESSION_MS;
+
+        if (isDropdownOpen(selectize, control)) {
+          closeDropdownFromControl(selectize, control);
+        } else {
+          selectize.focus();
+          selectize.open();
+          disableKeyboardActiveState(selectize);
+          clearUnhoveredActiveOptionsSoon(selectize);
+          updateOpenCursor(selectize, control);
+        }
+      },
+      true
+    );
+
+    ["click", "focusin"].forEach((eventName) => {
+      control.addEventListener(
+        eventName,
+        (event) => {
+          if (shouldSuppressFollowUp()) {
+            suppressControlEvent(event);
+          }
+        },
+        true
+      );
+    });
+
+    if (selectize.on) {
+      selectize.on("dropdown_open", () => updateOpenCursor(selectize, control));
+      selectize.on("dropdown_close", () => updateOpenCursor(selectize, control));
+      selectize.on("blur", () => updateOpenCursor(selectize, control));
+    }
+  };
+
   const enhanceMultiSelect = (select) => {
     if (!select || !select.multiple || select.hasAttribute(ENHANCED_ATTR)) {
       return false;
@@ -231,9 +653,36 @@
     decorateGroupHeaders(selectize);
     observeDropdown(selectize);
     keepActiveStateHoverBound(selectize);
+    addSelectedPlaceholder(selectize);
+    addCollapsedGroupItems(selectize);
+    addControlToggleBehaviour(selectize);
+    addHeaderClearButton(select, selectize);
 
     if (selectize.$control && selectize.$control[0]) {
       selectize.$control[0].addEventListener("keydown", (event) => {
+        const input = controlInputFor(selectize);
+        const isSelectAll = (
+          event.key.toLowerCase() === "a" &&
+          (event.ctrlKey || event.metaKey) &&
+          !event.altKey
+        );
+        const isRemovalKey = event.key === "Backspace" || event.key === "Delete";
+
+        if (isSelectAll) {
+          suppressKeyboardEvent(event);
+
+          if (inputHasSearchText(input) && input.select) {
+            input.select();
+          }
+
+          return;
+        }
+
+        if (isRemovalKey && !inputHasSearchText(input)) {
+          suppressKeyboardEvent(event);
+          return;
+        }
+
         if (
           NAVIGATION_KEYS.has(event.key) &&
           !event.ctrlKey &&

--- a/www/multi-selectize-behaviour.js
+++ b/www/multi-selectize-behaviour.js
@@ -11,6 +11,7 @@
   const ADD_PLACEHOLDER_CLASS = "multi-selectize-add-placeholder";
   const ADD_PLACEHOLDER_TEXT = "Click to add more filters";
   const GROUP_ITEM_CLASS = "multi-selectize-group-item";
+  const ITEM_LABEL_CLASS = "multi-selectize-item-label";
   const GROUP_ITEM_REMOVE_CLASS = "multi-selectize-group-item-remove";
   const HIDDEN_GROUP_ITEM_CLASS = "multi-selectize-hidden-group-item";
   const CLOSE_SUPPRESSION_MS = 350;
@@ -22,6 +23,12 @@
     "PageDown",
     "PageUp",
   ]);
+  const FILTER_DIMENSIONS = [
+    { suffix: "_end_use", dimension: "EndUse", groupDimension: "EndUseGroup" },
+    { suffix: "_fuels", dimension: "Fuel", groupDimension: "FuelGroup" },
+    { suffix: "_sectors", dimension: "Sector", groupDimension: "SectorGroup" },
+    { suffix: "_technologies", dimension: "Technology", groupDimension: "TechnologyGroup" },
+  ];
 
   const dropdownElement = (selectize) => (
     selectize.$dropdown && selectize.$dropdown[0]
@@ -175,6 +182,107 @@
     event.stopImmediatePropagation();
   };
 
+  const selectDimensionsFor = (selectize) => {
+    const select = selectize.$input && selectize.$input[0];
+    const selectId = select && select.id;
+
+    if (!selectId) {
+      return null;
+    }
+
+    return FILTER_DIMENSIONS.find((entry) => selectId.endsWith(entry.suffix)) || null;
+  };
+
+  const paletteColourFor = (label, dimension) => {
+    const palette = window.EEUD_SELECTIZE_COLOURS || {};
+    const dimensionPalette = palette[dimension] || {};
+    return dimensionPalette[String(label)] || null;
+  };
+
+  const relativeLuminance = (red, green, blue) => {
+    const toLinear = (channel) => {
+      const normalised = channel / 255;
+      return normalised <= 0.04045
+        ? normalised / 12.92
+        : ((normalised + 0.055) / 1.055) ** 2.4;
+    };
+
+    return (
+      0.2126 * toLinear(red) +
+      0.7152 * toLinear(green) +
+      0.0722 * toLinear(blue)
+    );
+  };
+
+  const textColourForBackground = (backgroundColour) => {
+    const match = String(backgroundColour || "").trim().match(/^#([0-9a-f]{6})$/i);
+
+    if (!match) {
+      return null;
+    }
+
+    const hex = match[1];
+    const red = parseInt(hex.slice(0, 2), 16);
+    const green = parseInt(hex.slice(2, 4), 16);
+    const blue = parseInt(hex.slice(4, 6), 16);
+
+    return relativeLuminance(red, green, blue) < 0.45 ? "#ffffff" : "#000000";
+  };
+
+  const setPriorityStyle = (element, property, value) => {
+    if (!element) {
+      return;
+    }
+
+    if (value) {
+      element.style.setProperty(property, value, "important");
+      return;
+    }
+
+    element.style.removeProperty(property);
+  };
+
+  const itemLabelForValue = (selectize, value) => {
+    const option = selectize.options && selectize.options[value];
+    return String((option && (option.label || option.text || option.value)) || value);
+  };
+
+  const selectedChipElements = (selectize) => {
+    const control = selectize.$control && selectize.$control[0];
+
+    if (!control) {
+      return [];
+    }
+
+    return Array.from(control.querySelectorAll(".item[data-value]"));
+  };
+
+  const applySelectedItemColours = (selectize) => {
+    const dimensions = selectDimensionsFor(selectize);
+
+    if (!dimensions) {
+      return;
+    }
+
+    selectedChipElements(selectize).forEach((item) => {
+      const groupValue = item.getAttribute("data-multi-selectize-group");
+      const label = groupValue || itemLabelForValue(selectize, item.getAttribute("data-value"));
+      const dimension = groupValue ? dimensions.groupDimension : dimensions.dimension;
+      const backgroundColour = paletteColourFor(label, dimension);
+      const textColour = textColourForBackground(backgroundColour);
+
+      setPriorityStyle(item, "background-color", backgroundColour);
+      setPriorityStyle(item, "color", textColour);
+    });
+  };
+
+  const applySelectedItemColoursSoon = (selectize) => {
+    window.requestAnimationFrame(() => {
+      applySelectedItemColours(selectize);
+      window.requestAnimationFrame(() => applySelectedItemColours(selectize));
+    });
+  };
+
   const optionGroupValues = (option, optgroupField) => {
     const optionGroup = option && option[optgroupField];
 
@@ -253,6 +361,46 @@
     updateCollapsedGroupItemsSoon(selectize);
   };
 
+  const wrapSelectedItemLabels = (selectize) => {
+    selectedItemElements(selectize).forEach((item) => {
+      const hasLabel = Array.from(item.children).some((child) => (
+        child.classList.contains(ITEM_LABEL_CLASS)
+      ));
+
+      if (hasLabel) {
+        return;
+      }
+
+      const labelNodes = Array.from(item.childNodes).filter((node) => {
+        if (node.nodeType === 3) {
+          return node.textContent.length > 0;
+        }
+
+        return node.nodeType === 1 && !node.classList.contains("remove");
+      });
+
+      if (!labelNodes.length) {
+        return;
+      }
+
+      const label = document.createElement("span");
+      label.className = ITEM_LABEL_CLASS;
+      item.insertBefore(label, labelNodes[0]);
+      labelNodes.forEach((node) => label.appendChild(node));
+    });
+  };
+
+  const wrapSelectedItemLabelsSoon = (selectize) => {
+    window.requestAnimationFrame(() => {
+      wrapSelectedItemLabels(selectize);
+      applySelectedItemColours(selectize);
+      window.requestAnimationFrame(() => {
+        wrapSelectedItemLabels(selectize);
+        applySelectedItemColours(selectize);
+      });
+    });
+  };
+
   const buildCollapsedGroupItem = (selectize, group) => {
     const item = document.createElement("div");
     const label = document.createElement("span");
@@ -261,6 +409,7 @@
     item.className = `${GROUP_ITEM_CLASS} item`;
     item.setAttribute("data-value", `__group__${group.groupValue}`);
     item.setAttribute("data-multi-selectize-group", group.groupValue);
+    label.className = ITEM_LABEL_CLASS;
     label.textContent = `All ${group.label}`;
 
     remove.className = `${GROUP_ITEM_REMOVE_CLASS} remove`;
@@ -318,7 +467,13 @@
   const updateCollapsedGroupItemsSoon = (selectize) => {
     window.requestAnimationFrame(() => {
       updateCollapsedGroupItems(selectize);
-      window.requestAnimationFrame(() => updateCollapsedGroupItems(selectize));
+      wrapSelectedItemLabels(selectize);
+      applySelectedItemColours(selectize);
+      window.requestAnimationFrame(() => {
+        updateCollapsedGroupItems(selectize);
+        wrapSelectedItemLabels(selectize);
+        applySelectedItemColours(selectize);
+      });
     });
   };
 
@@ -655,6 +810,7 @@
     keepActiveStateHoverBound(selectize);
     addSelectedPlaceholder(selectize);
     addCollapsedGroupItems(selectize);
+    wrapSelectedItemLabelsSoon(selectize);
     addControlToggleBehaviour(selectize);
     addHeaderClearButton(select, selectize);
 
@@ -706,6 +862,9 @@
       selectize.on("type", () => {
         window.requestAnimationFrame(() => decorateGroupHeaders(selectize));
       });
+      ["change", "item_add", "item_remove"].forEach((eventName) => {
+        selectize.on(eventName, () => wrapSelectedItemLabelsSoon(selectize));
+      });
     }
 
     return true;
@@ -714,6 +873,14 @@
   const enhanceAllMultiSelects = () => {
     document.querySelectorAll("select.shiny-input-select[multiple]").forEach((select) => {
       enhanceMultiSelect(select);
+    });
+  };
+
+  const applyAllSelectedItemColoursSoon = () => {
+    document.querySelectorAll("select.shiny-input-select[multiple]").forEach((select) => {
+      if (select.selectize) {
+        applySelectedItemColoursSoon(select.selectize);
+      }
     });
   };
 
@@ -736,5 +903,9 @@
   document.addEventListener("shiny:connected", () => {
     enhanceAllMultiSelects();
     startEnhancementRetries();
+  });
+
+  document.addEventListener("eeud-selectize-colours-ready", () => {
+    applyAllSelectedItemColoursSoon();
   });
 })();

--- a/www/selectize-colours.js
+++ b/www/selectize-colours.js
@@ -1,0 +1,81 @@
+(() => {
+  const PALETTE_URL = "data/eeud-colour-palette-2026.csv";
+  const READY_EVENT = "eeud-selectize-colours-ready";
+
+  const parseCsvLine = (line) => {
+    const values = [];
+    let value = "";
+    let inQuotes = false;
+
+    for (let index = 0; index < line.length; index += 1) {
+      const character = line[index];
+      const nextCharacter = line[index + 1];
+
+      if (character === '"' && inQuotes && nextCharacter === '"') {
+        value += '"';
+        index += 1;
+      } else if (character === '"') {
+        inQuotes = !inQuotes;
+      } else if (character === "," && !inQuotes) {
+        values.push(value);
+        value = "";
+      } else {
+        value += character;
+      }
+    }
+
+    values.push(value);
+    return values;
+  };
+
+  const parsePalette = (csvText) => {
+    const lines = csvText.trim().split(/\r?\n/);
+    const headers = parseCsvLine(lines.shift() || "");
+    const dimensionIndex = headers.indexOf("Dimension");
+    const labelIndex = headers.indexOf("Label");
+    const colourIndex = headers.indexOf("Colour");
+    const palette = {};
+
+    lines.forEach((line) => {
+      if (!line.trim()) {
+        return;
+      }
+
+      const values = parseCsvLine(line);
+      const dimension = values[dimensionIndex];
+      const label = values[labelIndex];
+      const colour = values[colourIndex];
+
+      if (!dimension || !label || !colour) {
+        return;
+      }
+
+      palette[dimension] = palette[dimension] || {};
+      palette[dimension][label] = colour;
+    });
+
+    return palette;
+  };
+
+  const dispatchReady = () => {
+    document.dispatchEvent(new CustomEvent(READY_EVENT));
+  };
+
+  window.EEUD_SELECTIZE_COLOURS = window.EEUD_SELECTIZE_COLOURS || {};
+
+  fetch(PALETTE_URL)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Unable to load ${PALETTE_URL}`);
+      }
+
+      return response.text();
+    })
+    .then((csvText) => {
+      window.EEUD_SELECTIZE_COLOURS = parsePalette(csvText);
+      dispatchReady();
+    })
+    .catch(() => {
+      dispatchReady();
+    });
+})();

--- a/www/single-selectize-behaviour.js
+++ b/www/single-selectize-behaviour.js
@@ -84,6 +84,7 @@
 
     const control = selectize.$control[0];
     select.setAttribute(ENHANCED_ATTR, "true");
+    let pendingMouseRelease = false;
     let suppressUntil = 0;
     let typeahead = "";
     let typeaheadTimer = null;
@@ -203,13 +204,25 @@
     control.addEventListener(
       "mousedown",
       (event) => {
-        if (!suppressEvent(event)) {
+        pendingMouseRelease = suppressEvent(event);
+      },
+      true
+    );
+
+    control.addEventListener(
+      "mouseup",
+      (event) => {
+        if (!pendingMouseRelease || !suppressEvent(event)) {
+          pendingMouseRelease = false;
           return;
         }
+
+        pendingMouseRelease = false;
 
         if (isDropdownOpen()) {
           closeDropdown();
         } else {
+          suppressUntil = window.performance.now() + 350;
           selectize.focus();
           selectize.open();
           disableKeyboardActiveState(selectize);
@@ -247,19 +260,11 @@
       selectTypeaheadMatch(event.key.toLowerCase());
     }, true);
 
-    ["mouseup", "click", "focusin"].forEach((eventName) => {
+    ["click", "focusin"].forEach((eventName) => {
       control.addEventListener(
         eventName,
         (event) => {
-          if (!shouldSuppressFollowUp()) {
-            if (eventName === "click") {
-              suppressEvent(event);
-            }
-            return;
-          }
-
-          if (suppressEvent(event)) {
-            selectize.close();
+          if (shouldSuppressFollowUp() && suppressEvent(event)) {
             window.requestAnimationFrame(syncInputState);
           }
         },

--- a/www/slider-label-bounds.js
+++ b/www/slider-label-bounds.js
@@ -10,30 +10,12 @@
     });
   };
 
-  const enableForceEdges = () => {
-    if (!window.jQuery) {
-      return false;
-    }
-
-    let applied = false;
-
-    sliderIds.forEach((id) => {
-      const slider = window.jQuery(`#${id}`).data("ionRangeSlider");
-      if (slider) {
-        slider.update({ force_edges: true });
-        applied = true;
-      }
-    });
-
-    return applied;
-  };
-
   const startForceEdgeRetries = () => {
     let attempts = 0;
     const intervalId = window.setInterval(() => {
       attempts += 1;
       setForceEdgeAttrs();
-      if (enableForceEdges() || attempts >= 40) {
+      if (attempts >= 40) {
         window.clearInterval(intervalId);
       }
     }, 150);


### PR DESCRIPTION
## Summary

This PR refines the dashboard filter experience, especially the grouped multi-select controls used across Explore, Timeseries, and Data views.

## Changes

- Adds custom multi-select behaviour for grouped filters:
  - “Add all” controls for option groups
  - collapsed “All <group>” selected chips when a full group is selected
  - per-filter clear buttons
  - “Click to add more filters” placeholder once selections exist
  - safer keyboard handling to avoid accidental chip removal
- Adds colour palette support for selected filter chips via `data/eeud-colour-palette-2026.csv`.
- Updates selectize styling, icons, dropdown behaviour, chip layout, and clear-button presentation.
- Refines single-select dropdown toggle handling.
- Tidies SCSS structure and improves sidebar, slider, card toolbar, and typography styling.
- Replaces sidebar `<h5>` headings with accessible styled section-title elements.
- Adds a rendered Explore chart title that reflects the selected period.
