### PR TITLE
No-Data bugfixes

### DIFF
--- a/eeca.scss
+++ b/eeca.scss
@@ -494,13 +494,32 @@ shiny-data-frame {
     }
 }
 
-.card-toolbar .cell-output-display:has(#render_explore_title),
+.card-toolbar .cell-output-display:has(#render_explore_title) {
+    align-items: flex-start !important;
+    align-self: flex-start !important;
+    display: flex !important;
+    flex: 1 1 auto;
+    height: auto !important;
+    min-width: 0 !important;
+}
+
 #render_explore_title {
-    display: contents !important;
+    align-items: flex-start !important;
+    align-self: flex-start !important;
+    display: flex !important;
+    flex: 1 1 auto;
+    height: auto !important;
+    min-width: 0 !important;
+    width: auto !important;
 }
 
 #render_explore_title > .card-title {
+    align-self: flex-start !important;
     margin-top: 0.1em;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* Overview toolbar */
@@ -892,12 +911,40 @@ $slider-selected-color: $sky-blue-light;
     width: 100% !important;
 
     &:hover,
-    &:focus,
     &:focus-visible {
         background-color: $secondary !important;
         border-left-color: $secondary !important;
         box-shadow: none !important;
         color: $sea-blue !important;
+        outline: 0 !important;
+    }
+
+    &:focus:not(:focus-visible) {
+        outline: 0 !important;
+    }
+
+    &.disabled,
+    &.download-button-disabled,
+    &[aria-disabled="true"] {
+        background-color: $silver !important;
+        border-left-color: transparent !important;
+        box-shadow: inset 0 -1px 0 0 $secondary !important;
+        color: $control-placeholder !important;
+        cursor: default !important;
+        pointer-events: auto !important;
+    }
+
+    &.disabled:hover,
+    &.disabled:focus-visible,
+    &.download-button-disabled:hover,
+    &.download-button-disabled:focus-visible,
+    &[aria-disabled="true"]:hover,
+    &[aria-disabled="true"]:focus-visible {
+        background-color: $silver !important;
+        border-left-color: transparent !important;
+        box-shadow: inset 0 -1px 0 0 $secondary !important;
+        color: $control-placeholder !important;
+        cursor: default !important;
         outline: 0 !important;
     }
 }

--- a/index.qmd
+++ b/index.qmd
@@ -22,6 +22,8 @@ format:
         - text: |
             <script src="www/slider-label-bounds.js?v=20260617-1"></script>
         - text: |
+            <script src="www/download-button-state.js?v=20260618-1"></script>
+        - text: |
             <script src="www/single-selectize-behaviour.js"></script>
         - text: |
             <script src="www/selectize-colours.js"></script>
@@ -48,6 +50,7 @@ from plotly.graph_objects import FigureWidget
 
 # Dashboard modules
 from shiny import render, reactive, ui
+from shiny.session import get_current_session
 from shinywidgets import render_widget, render_plotly
 
 eeud = pd.read_csv('./data/EEUD-20032026.csv')#.set_index('Row')
@@ -240,7 +243,18 @@ def empty_data_message():
     return ui.div(EMPTY_DATA_MESSAGE, class_="empty-data-message")
 
 def empty_data_figure(title):
-    fig = go.Figure()
+    # Keep a real trace in the figure. Annotation-only Plotly widgets can be
+    # brittle when they are hidden in a tab and then re-rendered.
+    fig = go.Figure(data=[
+        go.Scatter(
+            x=[0],
+            y=[0],
+            mode="markers",
+            marker=dict(color="rgba(0,0,0,0)", size=1),
+            hoverinfo="skip",
+            showlegend=False,
+        )
+    ])
     fig.update_layout(
         annotations=[
             dict(
@@ -270,6 +284,7 @@ def empty_data_figure(title):
         showlegend=False,
         xaxis=dict(
             fixedrange=True,
+            range=[-1, 1],
             showgrid=False,
             showticklabels=False,
             visible=False,
@@ -277,6 +292,7 @@ def empty_data_figure(title):
         ),
         yaxis=dict(
             fixedrange=True,
+            range=[-1, 1],
             showgrid=False,
             showticklabels=False,
             visible=False,
@@ -287,6 +303,13 @@ def empty_data_figure(title):
 
 def csv_download_filename(title):
     return f"{slugify_download_title(title) or 'eeud-data'}.csv"
+
+async def set_download_button_disabled(button_id, disabled):
+    session = get_current_session()
+    await session.send_custom_message(
+        "download-button-state",
+        {"id": button_id, "disabled": bool(disabled)}
+    )
 
 DOWNLOAD_FILTER_COLUMNS = {
     "EndUse": "End Use",
@@ -1182,6 +1205,13 @@ def explore_eeud_filtered():
 
     return data
 
+@reactive.effect
+async def update_explore_download_button_state():
+    await set_download_button_disabled(
+        "download_explore_filtered_data",
+        explore_eeud_filtered().empty
+    )
+
 ```
 
 <br/>
@@ -1398,6 +1428,13 @@ def timeseries_eeud_filtered():
         data = data[data['EndUse'].isin(input.timeseries_end_use())]
 
     return data
+
+@reactive.effect
+async def update_timeseries_download_button_state():
+    await set_download_button_disabled(
+        "download_timeseries_filtered_data",
+        timeseries_eeud_filtered().empty
+    )
 ```
 
 <br/>
@@ -1628,6 +1665,13 @@ def data_eeud_filtered():
     data = data[['EndUse', 'EndUseGroup', 'Fuel', 'FuelGroup', 'Sector', 'SectorANZSIC', 'SectorGroup', 'Technology', 'TechnologyGroup', 'Transport', 'TJ', 'Period', 'PeriodEndDate']]
 
     return data
+
+@reactive.effect
+async def update_data_download_button_state():
+    await set_download_button_disabled(
+        "download_data_filtered_data",
+        data_eeud_filtered().empty
+    )
 ```
 
 <br/>

--- a/www/download-button-state.js
+++ b/www/download-button-state.js
@@ -1,0 +1,115 @@
+(() => {
+  const DISABLED_CLASS = "download-button-disabled";
+  const DISABLED_HREF_ATTR = "data-download-disabled-href";
+  const STATE_BY_ID = new Map();
+
+  const setDownloadButtonState = (id, disabled) => {
+    const button = document.getElementById(id);
+    if (!button) {
+      return;
+    }
+
+    if (disabled) {
+      const currentHref = button.getAttribute("href");
+      if (currentHref !== null) {
+        button.setAttribute(DISABLED_HREF_ATTR, currentHref);
+        button.removeAttribute("href");
+      }
+    } else {
+      const storedHref = button.getAttribute(DISABLED_HREF_ATTR);
+      if (!button.hasAttribute("href") && storedHref) {
+        button.setAttribute("href", storedHref);
+      }
+      if (storedHref !== null) {
+        button.removeAttribute(DISABLED_HREF_ATTR);
+      }
+    }
+
+    if (button.classList.contains(DISABLED_CLASS) !== disabled) {
+      button.classList.toggle(DISABLED_CLASS, disabled);
+    }
+
+    if (disabled) {
+      if (!button.classList.contains("disabled")) {
+        button.classList.add("disabled");
+      }
+      if (!button.hasAttribute("data-download-disabled")) {
+        button.setAttribute("data-download-disabled", "");
+      }
+      if (button.getAttribute("aria-disabled") !== "true") {
+        button.setAttribute("aria-disabled", "true");
+      }
+      if (button.getAttribute("tabindex") !== "-1") {
+        button.setAttribute("tabindex", "-1");
+      }
+    } else {
+      if (button.classList.contains("disabled")) {
+        button.classList.remove("disabled");
+      }
+      if (button.hasAttribute("data-download-disabled")) {
+        button.removeAttribute("data-download-disabled");
+      }
+      if (button.hasAttribute("aria-disabled")) {
+        button.removeAttribute("aria-disabled");
+      }
+      if (button.hasAttribute("tabindex")) {
+        button.removeAttribute("tabindex");
+      }
+    }
+  };
+
+  const applyStoredStates = () => {
+    STATE_BY_ID.forEach((disabled, id) => {
+      setDownloadButtonState(id, disabled);
+    });
+  };
+
+  const handleStateMessage = (message) => {
+    if (!message || !message.id) {
+      return;
+    }
+
+    const disabled = Boolean(message.disabled);
+    STATE_BY_ID.set(message.id, disabled);
+    setDownloadButtonState(message.id, disabled);
+  };
+
+  const registerHandler = () => {
+    if (!window.Shiny || !window.Shiny.addCustomMessageHandler) {
+      window.setTimeout(registerHandler, 50);
+      return;
+    }
+
+    window.Shiny.addCustomMessageHandler(
+      "download-button-state",
+      handleStateMessage
+    );
+    applyStoredStates();
+  };
+
+  document.addEventListener(
+    "click",
+    (event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const button = target ? target.closest("a[data-download-disabled]") : null;
+      if (!button) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    },
+    true
+  );
+
+  document.addEventListener("DOMContentLoaded", () => {
+    registerHandler();
+
+    const observer = new MutationObserver(applyStoredStates);
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["href", "class", "aria-disabled", "tabindex"],
+      subtree: true,
+    });
+  });
+})();


### PR DESCRIPTION
## Summary

Fixes several no-data state issues in the dashboard, especially on the Explore page.

- Stabilises the Explore chart/title when filters produce no data and the user switches tabs.
- Keeps the dynamic Explore title aligned with the Time Series card toolbar title.
- Disables download buttons when their filtered dataset is empty.
- Prevents disabled download links from being clicked, opened in a new tab, or exposing a downloadable URL on hover.
- Styles disabled download buttons with the placeholder colour and default cursor.

## Details

The no-data Plotly figure now includes an invisible trace rather than being annotation-only. This avoids a brittle widget state that could get stuck after tab hide/show cycles.

The Explore title output now remains a real flex element instead of using `display: contents`, giving Shiny a stable output wrapper while preserving toolbar alignment.

Download button state is driven from Shiny reactive effects for Explore, Time Series, and Data filters. A small client-side helper applies disabled state, removes/restores `href`, and preserves the state when Shiny refreshes download links.

## Testing

- Deployed to shinyapps dev dashboard: https://eeca-nz.shinyapps.io/eeud-dashboard-dev/
- Manually checked no-data behaviour during dashboard interaction
- The No-Data state can be replicated easily by setting fuel type to a renewable, and sector to transport.